### PR TITLE
Kartik/typedef optional references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,9 @@ endif()
 include(cmake/HandleGeneralOptions.cmake)   # CMake build options
 
 # Libraries:
-if (NOT GTSAM_NO_BOOST_CPP17)
+# if (NOT GTSAM_NO_BOOST_CPP17)
   include(cmake/HandleBoost.cmake)            # Boost
-endif()
+# endif()
   
 include(cmake/HandleCCache.cmake)           # ccache
 include(cmake/HandleCPack.cmake)            # CPack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 option(GTSAM_NO_BOOST_CPP17 "Require and use boost" ON)
 add_definitions(-Wno-deprecated-declarations)
+add_definitions(-ftemplate-backtrace-limit=0)
 
   set(CMAKE_CXX_STANDARD 17)
 if (GTSAM_NO_BOOST_CPP17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ option(GTSAM_NO_BOOST_CPP17 "Require and use boost" ON)
 add_definitions(-Wno-deprecated-declarations)
 add_definitions(-ftemplate-backtrace-limit=0)
 
-  set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
 if (GTSAM_NO_BOOST_CPP17)
   add_definitions(-DNO_BOOST_CPP17)
 endif()
@@ -99,7 +99,7 @@ add_subdirectory(timing)
 
 # Build gtsam_unstable
 if (GTSAM_BUILD_UNSTABLE)
-	# add_subdirectory(gtsam_unstable)
+	add_subdirectory(gtsam_unstable)
 endif()
 
 # This is the new wrapper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,9 @@ endif()
 option(GTSAM_NO_BOOST_CPP17 "Require and use boost" ON)
 add_definitions(-Wno-deprecated-declarations)
 
+  set(CMAKE_CXX_STANDARD 17)
 if (GTSAM_NO_BOOST_CPP17)
   add_definitions(-DNO_BOOST_CPP17)
-  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 # Set the version number for the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,6 @@ if(NOT DEFINED CMAKE_MACOSX_RPATH)
   set(CMAKE_MACOSX_RPATH 0)
 endif()
 
-add_definitions(-Wno-deprecated-declarations)
-add_definitions(-ftemplate-backtrace-limit=0)
-
 set(CMAKE_CXX_STANDARD 17)
 
 # Set the version number for the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,10 @@ if(NOT DEFINED CMAKE_MACOSX_RPATH)
   set(CMAKE_MACOSX_RPATH 0)
 endif()
 
-option(GTSAM_NO_BOOST_CPP17 "Require and use boost" ON)
 add_definitions(-Wno-deprecated-declarations)
 add_definitions(-ftemplate-backtrace-limit=0)
 
 set(CMAKE_CXX_STANDARD 17)
-if (GTSAM_NO_BOOST_CPP17)
-  add_definitions(-DNO_BOOST_CPP17)
-endif()
 
 # Set the version number for the library
 set (GTSAM_VERSION_MAJOR 4)
@@ -60,10 +56,7 @@ endif()
 include(cmake/HandleGeneralOptions.cmake)   # CMake build options
 
 # Libraries:
-# if (NOT GTSAM_NO_BOOST_CPP17)
-  include(cmake/HandleBoost.cmake)            # Boost
-# endif()
-  
+include(cmake/HandleBoost.cmake)            # Boost
 include(cmake/HandleCCache.cmake)           # ccache
 include(cmake/HandleCPack.cmake)            # CPack
 include(cmake/HandleEigen.cmake)            # Eigen3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ add_subdirectory(timing)
 
 # Build gtsam_unstable
 if (GTSAM_BUILD_UNSTABLE)
-    add_subdirectory(gtsam_unstable)
+	# add_subdirectory(gtsam_unstable)
 endif()
 
 # This is the new wrapper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@ if(NOT DEFINED CMAKE_MACOSX_RPATH)
 endif()
 
 option(GTSAM_NO_BOOST_CPP17 "Require and use boost" ON)
+add_definitions(-Wno-deprecated-declarations)
 
 if (GTSAM_NO_BOOST_CPP17)
+  add_definitions(-DNO_BOOST_CPP17)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
@@ -57,9 +59,8 @@ endif()
 include(cmake/HandleGeneralOptions.cmake)   # CMake build options
 
 # Libraries:
-if (GTSAM_NO_BOOST_CPP17)
+if (NOT GTSAM_NO_BOOST_CPP17)
   include(cmake/HandleBoost.cmake)            # Boost
-  add_definitions(-DNO_BOOST_CPP17)
 endif()
   
 include(cmake/HandleCCache.cmake)           # ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ add_subdirectory(timing)
 
 # Build gtsam_unstable
 if (GTSAM_BUILD_UNSTABLE)
-	add_subdirectory(gtsam_unstable)
+  add_subdirectory(gtsam_unstable)
 endif()
 
 # This is the new wrapper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ if(NOT DEFINED CMAKE_MACOSX_RPATH)
   set(CMAKE_MACOSX_RPATH 0)
 endif()
 
+option(GTSAM_NO_BOOST_CPP17 "Require and use boost" ON)
+
+if (GTSAM_NO_BOOST_CPP17)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 # Set the version number for the library
 set (GTSAM_VERSION_MAJOR 4)
 set (GTSAM_VERSION_MINOR 2)
@@ -51,7 +57,11 @@ endif()
 include(cmake/HandleGeneralOptions.cmake)   # CMake build options
 
 # Libraries:
-include(cmake/HandleBoost.cmake)            # Boost
+if (GTSAM_NO_BOOST_CPP17)
+  include(cmake/HandleBoost.cmake)            # Boost
+  add_definitions(-DNO_BOOST_CPP17)
+endif()
+  
 include(cmake/HandleCCache.cmake)           # ccache
 include(cmake/HandleCPack.cmake)            # CPack
 include(cmake/HandleEigen.cmake)            # Eigen3

--- a/doc/Code/LocalizationFactor.cpp
+++ b/doc/Code/LocalizationFactor.cpp
@@ -3,6 +3,7 @@ class UnaryFactor: public NoiseModelFactor1<Pose2> {
   
 public:
   using gtsam::NoiseModelFactor1<Pose2>::evaluateError;
+
   UnaryFactor(Key j, double x, double y, const SharedNoiseModel& model):
     NoiseModelFactor1<Pose2>(model, j), mx_(x), my_(y) {}
 

--- a/doc/Code/LocalizationFactor.cpp
+++ b/doc/Code/LocalizationFactor.cpp
@@ -2,11 +2,11 @@ class UnaryFactor: public NoiseModelFactor1<Pose2> {
   double mx_, my_; ///< X and Y measurements
   
 public:
+  using gtsam::NoiseModelFactor1<Pose2>::evaluateError;
   UnaryFactor(Key j, double x, double y, const SharedNoiseModel& model):
     NoiseModelFactor1<Pose2>(model, j), mx_(x), my_(y) {}
 
-  Vector evaluateError(const Pose2& q, 
-      OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Pose2& q, OptionalMatrixType H) const override {
     const Rot2& R = q.rotation();
     if (H) (*H) = (gtsam::Matrix(2, 3) <<
             R.c(), -R.s(), 0.0,

--- a/doc/Code/LocalizationFactor.cpp
+++ b/doc/Code/LocalizationFactor.cpp
@@ -6,7 +6,7 @@ public:
     NoiseModelFactor1<Pose2>(model, j), mx_(x), my_(y) {}
 
   Vector evaluateError(const Pose2& q, 
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     const Rot2& R = q.rotation();
     if (H) (*H) = (gtsam::Matrix(2, 3) <<
             R.c(), -R.s(), 0.0,

--- a/doc/Code/LocalizationFactor.cpp
+++ b/doc/Code/LocalizationFactor.cpp
@@ -2,6 +2,8 @@ class UnaryFactor: public NoiseModelFactor1<Pose2> {
   double mx_, my_; ///< X and Y measurements
   
 public:
+
+  // Provide access to the Matrix& version of evaluateError:
   using gtsam::NoiseModelFactor1<Pose2>::evaluateError;
 
   UnaryFactor(Key j, double x, double y, const SharedNoiseModel& model):

--- a/examples/CameraResectioning.cpp
+++ b/examples/CameraResectioning.cpp
@@ -46,8 +46,7 @@ public:
   }
 
   /// evaluate the error
-  Vector evaluateError(const Pose3& pose, OptionalMatrixType H =
-      OptionalNone) const override {
+  Vector evaluateError(const Pose3& pose, OptionalMatrixType H) const override {
     PinholeCamera<Cal3_S2> camera(pose, *K_);
     return camera.project(P_, H, OptionalNone, OptionalNone) - p_;
   }

--- a/examples/CameraResectioning.cpp
+++ b/examples/CameraResectioning.cpp
@@ -46,10 +46,10 @@ public:
   }
 
   /// evaluate the error
-  Vector evaluateError(const Pose3& pose, boost::optional<Matrix&> H =
-      boost::none) const override {
+  Vector evaluateError(const Pose3& pose, OptionalMatrixType H =
+      OptionalNone) const override {
     PinholeCamera<Cal3_S2> camera(pose, *K_);
-    return camera.project(P_, H, boost::none, boost::none) - p_;
+    return camera.project(P_, H, OptionalNone, OptionalNone) - p_;
   }
 };
 

--- a/examples/LocalizationExample.cpp
+++ b/examples/LocalizationExample.cpp
@@ -84,7 +84,7 @@ class UnaryFactor: public NoiseModelFactorN<Pose2> {
   // The first is the 'evaluateError' function. This function implements the desired measurement
   // function, returning a vector of errors when evaluated at the provided variable value. It
   // must also calculate the Jacobians for this measurement function, if requested.
-  Vector evaluateError(const Pose2& q, boost::optional<Matrix&> H = boost::none) const override {
+  Vector evaluateError(const Pose2& q, OptionalMatrixType H = OptionalNone) const override {
     // The measurement function for a GPS-like measurement h(q) which predicts the measurement (m) is h(q) = q, q = [qx qy qtheta]
     // The error is then simply calculated as E(q) = h(q) - m:
     // error_x = q.x - mx

--- a/examples/LocalizationExample.cpp
+++ b/examples/LocalizationExample.cpp
@@ -71,6 +71,7 @@ class UnaryFactor: public NoiseModelFactorN<Pose2> {
   double mx_, my_;
 
  public:
+
   // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor1<Pose2>::evaluateError;
 

--- a/examples/LocalizationExample.cpp
+++ b/examples/LocalizationExample.cpp
@@ -71,6 +71,7 @@ class UnaryFactor: public NoiseModelFactorN<Pose2> {
   double mx_, my_;
 
  public:
+  using NoiseModelFactor1<Pose2>::evaluateError;
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<UnaryFactor> shared_ptr;
 
@@ -84,7 +85,7 @@ class UnaryFactor: public NoiseModelFactorN<Pose2> {
   // The first is the 'evaluateError' function. This function implements the desired measurement
   // function, returning a vector of errors when evaluated at the provided variable value. It
   // must also calculate the Jacobians for this measurement function, if requested.
-  Vector evaluateError(const Pose2& q, OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Pose2& q, OptionalMatrixType H) const override {
     // The measurement function for a GPS-like measurement h(q) which predicts the measurement (m) is h(q) = q, q = [qx qy qtheta]
     // The error is then simply calculated as E(q) = h(q) - m:
     // error_x = q.x - mx

--- a/examples/LocalizationExample.cpp
+++ b/examples/LocalizationExample.cpp
@@ -71,7 +71,9 @@ class UnaryFactor: public NoiseModelFactorN<Pose2> {
   double mx_, my_;
 
  public:
+  // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor1<Pose2>::evaluateError;
+
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<UnaryFactor> shared_ptr;
 

--- a/gtsam/base/OptionalJacobian.h
+++ b/gtsam/base/OptionalJacobian.h
@@ -92,8 +92,8 @@ public:
   }
 
   /// Constructor that will resize a dynamic matrix (unless already correct)
-  OptionalJacobian(Eigen::MatrixXd* dynamic)
-      : map_(nullptr) {
+  OptionalJacobian(Eigen::MatrixXd* dynamic) :
+      map_(nullptr) {
     if (dynamic) {
       dynamic->resize(Rows, Cols);  // no malloc if correct size
       usurp(dynamic->data());

--- a/gtsam/base/OptionalJacobian.h
+++ b/gtsam/base/OptionalJacobian.h
@@ -94,8 +94,10 @@ public:
   /// Constructor that will resize a dynamic matrix (unless already correct)
   OptionalJacobian(Eigen::MatrixXd* dynamic) :
       map_(nullptr) {
-    dynamic->resize(Rows, Cols); // no malloc if correct size
-    usurp(dynamic->data());
+	if (dynamic) {
+      dynamic->resize(Rows, Cols); // no malloc if correct size
+      usurp(dynamic->data());
+	}
   }
 
   /**

--- a/gtsam/base/OptionalJacobian.h
+++ b/gtsam/base/OptionalJacobian.h
@@ -92,12 +92,12 @@ public:
   }
 
   /// Constructor that will resize a dynamic matrix (unless already correct)
-  OptionalJacobian(Eigen::MatrixXd* dynamic) :
-      map_(nullptr) {
-	if (dynamic) {
-      dynamic->resize(Rows, Cols); // no malloc if correct size
+  OptionalJacobian(Eigen::MatrixXd* dynamic)
+      : map_(nullptr) {
+    if (dynamic) {
+      dynamic->resize(Rows, Cols);  // no malloc if correct size
       usurp(dynamic->data());
-	}
+    }
   }
 
   /**

--- a/gtsam/base/numericalDerivative.h
+++ b/gtsam/base/numericalDerivative.h
@@ -35,7 +35,7 @@ namespace gtsam {
  *
  * Usage of the boost bind version to rearrange arguments:
  *   for a function with one relevant param and an optional derivative:
- *     Foo bar(const Obj& a, boost::optional<Matrix&> H1)
+ *     Foo bar(const Obj& a, OptionalMatrixType H1)
  *   Use boost.bind to restructure:
  *     std::bind(bar, std::placeholders::_1, boost::none)
  *   This syntax will fix the optional argument to boost::none, while using the first argument provided

--- a/gtsam/geometry/CameraSet.h
+++ b/gtsam/geometry/CameraSet.h
@@ -106,8 +106,8 @@ class CameraSet : public std::vector<CAMERA, Eigen::aligned_allocator<CAMERA>> {
    */
   template <class POINT>
   ZVector project2(const POINT& point,                          //
-                   boost::optional<FBlocks&> Fs = boost::none,  //
-                   boost::optional<Matrix&> E = boost::none) const {
+                   FBlocks* Fs = nullptr,  //
+                   Matrix* E = nullptr) const {
     static const int N = FixedDimension<POINT>::value;
 
     // Allocate result
@@ -131,12 +131,33 @@ class CameraSet : public std::vector<CAMERA, Eigen::aligned_allocator<CAMERA>> {
     return z;
   }
 
+  /** An overload o the project2 function to accept
+   * full matrices and vectors and pass it to the pointer
+   * version of the function
+   */
+  template <class POINT, class... OptArgs>
+  ZVector project2(const POINT& point, OptArgs&... args) const {
+    // pass it to the pointer version of the function
+    return project2(point, (&args)...);
+  }
+
   /// Calculate vector [project2(point)-z] of re-projection errors
   template <class POINT>
   Vector reprojectionError(const POINT& point, const ZVector& measured,
-                           boost::optional<FBlocks&> Fs = boost::none,  //
-                           boost::optional<Matrix&> E = boost::none) const {
+                           FBlocks* Fs = nullptr,  //
+                           Matrix* E = nullptr) const {
     return ErrorVector(project2(point, Fs, E), measured);
+  }
+
+  /** An overload o the reprojectionError function to accept
+   * full matrices and vectors and pass it to the pointer
+   * version of the function
+   */
+  template <class POINT, class... OptArgs>
+  Vector reprojectionError(const POINT& point, const ZVector& measured,
+                           OptArgs&... args) const {
+    // pass it to the pointer version of the function
+    return reprojectionError(point, measured, (&args)...);
   }
 
   /**

--- a/gtsam/inference/VariableIndex-inl.h
+++ b/gtsam/inference/VariableIndex-inl.h
@@ -24,8 +24,7 @@ namespace gtsam {
 
 /* ************************************************************************* */
 template<class FG>
-void VariableIndex::augment(const FG& factors,
-    boost::optional<const FactorIndices&> newFactorIndices) {
+void VariableIndex::augment(const FG& factors, const FactorIndices* newFactorIndices) {
   gttic(VariableIndex_augment);
 
   // Augment index for each factor

--- a/gtsam/inference/VariableIndex.h
+++ b/gtsam/inference/VariableIndex.h
@@ -126,7 +126,16 @@ class GTSAM_EXPORT VariableIndex {
    * solving problems incrementally.
    */
   template<class FG>
-  void augment(const FG& factors, boost::optional<const FactorIndices&> newFactorIndices = boost::none);
+  void augment(const FG& factors, const FactorIndices* newFactorIndices = nullptr);
+
+  /**
+   * An overload of augment() that takes a single factor. and l-value
+   * reference to FactorIndeces.
+   */
+  template<class FG>
+  void augment(const FG& factor, const FactorIndices& newFactorIndices) {
+    augment(factor, &newFactorIndices);
+  }
 
   /**
    * Augment the variable index after an existing factor now affects to more

--- a/gtsam/linear/IterativeSolver.cpp
+++ b/gtsam/linear/IterativeSolver.cpp
@@ -84,8 +84,7 @@ string IterativeOptimizationParameters::verbosityTranslator(
 
 /*****************************************************************************/
 VectorValues IterativeSolver::optimize(const GaussianFactorGraph &gfg,
-    boost::optional<const KeyInfo&> keyInfo,
-    boost::optional<const std::map<Key, Vector>&> lambda) {
+    const KeyInfo* keyInfo, const std::map<Key, Vector>* lambda) {
   return optimize(gfg, keyInfo ? *keyInfo : KeyInfo(gfg),
       lambda ? *lambda : std::map<Key, Vector>());
 }

--- a/gtsam/linear/IterativeSolver.h
+++ b/gtsam/linear/IterativeSolver.h
@@ -93,8 +93,8 @@ public:
 
   /* interface to the nonlinear optimizer, without metadata, damping and initial estimate */
   GTSAM_EXPORT VectorValues optimize(const GaussianFactorGraph &gfg,
-      boost::optional<const KeyInfo&> = boost::none,
-      boost::optional<const std::map<Key, Vector>&> lambda = boost::none);
+      const KeyInfo* = nullptr,
+      const std::map<Key, Vector>* lambda = nullptr);
 
   /* interface to the nonlinear optimizer, without initial estimate */
   GTSAM_EXPORT VectorValues optimize(const GaussianFactorGraph &gfg, const KeyInfo &keyInfo,

--- a/gtsam/linear/linearAlgorithms-inst.h
+++ b/gtsam/linear/linearAlgorithms-inst.h
@@ -21,8 +21,9 @@
 #include <gtsam/linear/GaussianConditional.h>
 #include <gtsam/base/treeTraversal-inst.h>
 
-#include <boost/optional.hpp>
 #include <boost/shared_ptr.hpp>
+
+#include <optional>
 
 namespace gtsam
 {
@@ -32,7 +33,7 @@ namespace gtsam
     {
       /* ************************************************************************* */
       struct OptimizeData {
-        boost::optional<OptimizeData&> parentData;
+        OptimizeData* parentData = nullptr;
         FastMap<Key, VectorValues::const_iterator> cliqueResults;
         //VectorValues ancestorResults;
         //VectorValues results;
@@ -55,7 +56,7 @@ namespace gtsam
           OptimizeData& parentData)
         {
           OptimizeData myData;
-          myData.parentData = parentData;
+          myData.parentData = &parentData;
           // Take any ancestor results we'll need
           for(Key parent: clique->conditional_->parents())
             myData.cliqueResults.emplace(parent, myData.parentData->cliqueResults.at(parent));

--- a/gtsam/navigation/AHRSFactor.cpp
+++ b/gtsam/navigation/AHRSFactor.cpp
@@ -119,8 +119,8 @@ bool AHRSFactor::equals(const NonlinearFactor& other, double tol) const {
 
 //------------------------------------------------------------------------------
 Vector AHRSFactor::evaluateError(const Rot3& Ri, const Rot3& Rj,
-    const Vector3& bias, boost::optional<Matrix&> H1,
-    boost::optional<Matrix&> H2, boost::optional<Matrix&> H3) const {
+    const Vector3& bias, OptionalMatrixType H1,
+    OptionalMatrixType H2, OptionalMatrixType H3) const {
 
   // Do bias correction, if (H3) will contain 3*3 derivative used below
   const Vector3 biascorrectedOmega = _PIM_.predict(bias, H3);

--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -142,6 +142,7 @@ public:
 
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /** Shorthand for a smart pointer to a factor */
 #if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5
   typedef typename boost::shared_ptr<AHRSFactor> shared_ptr;

--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -140,6 +140,7 @@ class GTSAM_EXPORT AHRSFactor: public NoiseModelFactorN<Rot3, Rot3, Vector3> {
 
 public:
 
+  using Base::evaluateError;
   /** Shorthand for a smart pointer to a factor */
 #if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5
   typedef typename boost::shared_ptr<AHRSFactor> shared_ptr;
@@ -179,9 +180,8 @@ public:
 
   /// vector of errors
   Vector evaluateError(const Rot3& rot_i, const Rot3& rot_j,
-      const Vector3& bias, OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone, OptionalMatrixType H3 =
-          OptionalNone) const override;
+      const Vector3& bias, OptionalMatrixType H1,
+      OptionalMatrixType H2, OptionalMatrixType H3) const override;
 
   /// predicted states from IMU
   /// TODO(frank): relationship with PIM predict ??

--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -140,6 +140,7 @@ class GTSAM_EXPORT AHRSFactor: public NoiseModelFactorN<Rot3, Rot3, Vector3> {
 
 public:
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /** Shorthand for a smart pointer to a factor */
 #if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5

--- a/gtsam/navigation/AHRSFactor.h
+++ b/gtsam/navigation/AHRSFactor.h
@@ -179,9 +179,9 @@ public:
 
   /// vector of errors
   Vector evaluateError(const Rot3& rot_i, const Rot3& rot_j,
-      const Vector3& bias, boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none, boost::optional<Matrix&> H3 =
-          boost::none) const override;
+      const Vector3& bias, OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone, OptionalMatrixType H3 =
+          OptionalNone) const override;
 
   /// predicted states from IMU
   /// TODO(frank): relationship with PIM predict ??

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -158,6 +158,7 @@ class GTSAM_EXPORT Pose3AttitudeFactor: public NoiseModelFactorN<Pose3>,
   typedef NoiseModelFactorN<Pose3> Base;
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -84,6 +84,7 @@ public:
 
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<Rot3AttitudeFactor> shared_ptr;
 

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -122,7 +122,7 @@ public:
 
   /** vector of errors */
   Vector evaluateError(const Rot3& nRb, //
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     return attitudeError(nRb, H);
   }
 
@@ -197,7 +197,7 @@ public:
 
   /** vector of errors */
   Vector evaluateError(const Pose3& nTb, //
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     Vector e = attitudeError(nTb.rotation(), H);
     if (H) {
       Matrix H23 = *H;

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -82,6 +82,7 @@ class GTSAM_EXPORT Rot3AttitudeFactor: public NoiseModelFactorN<Rot3>, public At
 
 public:
 
+  using Base::evaluateError;
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<Rot3AttitudeFactor> shared_ptr;
 
@@ -156,6 +157,7 @@ class GTSAM_EXPORT Pose3AttitudeFactor: public NoiseModelFactorN<Pose3>,
   typedef NoiseModelFactorN<Pose3> Base;
 
 public:
+  using Base::evaluateError;
 
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<Pose3AttitudeFactor> shared_ptr;

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -122,8 +122,7 @@ public:
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
 
   /** vector of errors */
-  Vector evaluateError(const Rot3& nRb, //
-      OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Rot3& nRb, OptionalMatrixType H) const override {
     return attitudeError(nRb, H);
   }
 
@@ -198,8 +197,7 @@ public:
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
 
   /** vector of errors */
-  Vector evaluateError(const Pose3& nTb, //
-      OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Pose3& nTb, OptionalMatrixType H) const override {
     Vector e = attitudeError(nTb.rotation(), H);
     if (H) {
       Matrix H23 = *H;

--- a/gtsam/navigation/AttitudeFactor.h
+++ b/gtsam/navigation/AttitudeFactor.h
@@ -82,6 +82,7 @@ class GTSAM_EXPORT Rot3AttitudeFactor: public NoiseModelFactorN<Rot3>, public At
 
 public:
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<Rot3AttitudeFactor> shared_ptr;
@@ -156,6 +157,7 @@ class GTSAM_EXPORT Pose3AttitudeFactor: public NoiseModelFactorN<Pose3>,
   typedef NoiseModelFactorN<Pose3> Base;
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// shorthand for a smart pointer to a factor

--- a/gtsam/navigation/BarometricFactor.cpp
+++ b/gtsam/navigation/BarometricFactor.cpp
@@ -43,8 +43,8 @@ bool BarometricFactor::equals(const NonlinearFactor& expected,
 
 //***************************************************************************
 Vector BarometricFactor::evaluateError(const Pose3& p, const double& bias,
-                                       boost::optional<Matrix&> H,
-                                       boost::optional<Matrix&> H2) const {
+                                       OptionalMatrixType H,
+                                       OptionalMatrixType H2) const {
     Matrix tH;
     Vector ret = (Vector(1) << (p.translation(tH).z() + bias - nT_)).finished();
     if (H) (*H) = tH.block<1, 6>(2, 0);

--- a/gtsam/navigation/BarometricFactor.h
+++ b/gtsam/navigation/BarometricFactor.h
@@ -78,8 +78,8 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
     /// vector of errors
     Vector evaluateError(
         const Pose3& p, const double& b,
-        boost::optional<Matrix&> H = boost::none,
-        boost::optional<Matrix&> H2 = boost::none) const override;
+        OptionalMatrixType H = OptionalNone,
+        OptionalMatrixType H2 = OptionalNone) const override;
 
     inline const double& measurementIn() const { return nT_; }
 

--- a/gtsam/navigation/BarometricFactor.h
+++ b/gtsam/navigation/BarometricFactor.h
@@ -38,6 +38,7 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
     double nT_;  ///< Height Measurement based on a standard atmosphere
 
    public:
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
     /// shorthand for a smart pointer to a factor
     typedef boost::shared_ptr<BarometricFactor> shared_ptr;

--- a/gtsam/navigation/BarometricFactor.h
+++ b/gtsam/navigation/BarometricFactor.h
@@ -38,6 +38,7 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
     double nT_;  ///< Height Measurement based on a standard atmosphere
 
    public:
+    using Base::evaluateError;
     /// shorthand for a smart pointer to a factor
     typedef boost::shared_ptr<BarometricFactor> shared_ptr;
 
@@ -76,10 +77,8 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
                 double tol = 1e-9) const override;
 
     /// vector of errors
-    Vector evaluateError(
-        const Pose3& p, const double& b,
-        OptionalMatrixType H = OptionalNone,
-        OptionalMatrixType H2 = OptionalNone) const override;
+    Vector evaluateError(const Pose3& p, const double& b, 
+            OptionalMatrixType H, OptionalMatrixType H2) const override;
 
     inline const double& measurementIn() const { return nT_; }
 

--- a/gtsam/navigation/BarometricFactor.h
+++ b/gtsam/navigation/BarometricFactor.h
@@ -38,6 +38,7 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
     double nT_;  ///< Height Measurement based on a standard atmosphere
 
    public:
+
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 

--- a/gtsam/navigation/BarometricFactor.h
+++ b/gtsam/navigation/BarometricFactor.h
@@ -40,6 +40,7 @@ class GTSAM_EXPORT BarometricFactor : public NoiseModelFactorN<Pose3, double> {
    public:
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
+
     /// shorthand for a smart pointer to a factor
     typedef boost::shared_ptr<BarometricFactor> shared_ptr;
 

--- a/gtsam/navigation/CombinedImuFactor.cpp
+++ b/gtsam/navigation/CombinedImuFactor.cpp
@@ -222,9 +222,9 @@ bool CombinedImuFactor::equals(const NonlinearFactor& other, double tol) const {
 Vector CombinedImuFactor::evaluateError(const Pose3& pose_i,
     const Vector3& vel_i, const Pose3& pose_j, const Vector3& vel_j,
     const imuBias::ConstantBias& bias_i, const imuBias::ConstantBias& bias_j,
-    boost::optional<Matrix&> H1, boost::optional<Matrix&> H2,
-    boost::optional<Matrix&> H3, boost::optional<Matrix&> H4,
-    boost::optional<Matrix&> H5, boost::optional<Matrix&> H6) const {
+    OptionalMatrixType H1, OptionalMatrixType H2,
+    OptionalMatrixType H3, OptionalMatrixType H4,
+    OptionalMatrixType H5, OptionalMatrixType H6) const {
 
   // error wrt bias evolution model (random walk)
   Matrix6 Hbias_i, Hbias_j;

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -268,6 +268,7 @@ private:
   PreintegratedCombinedMeasurements _PIM_;
 
 public:
+  using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */
 #if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5
@@ -324,12 +325,9 @@ public:
   Vector evaluateError(const Pose3& pose_i, const Vector3& vel_i,
       const Pose3& pose_j, const Vector3& vel_j,
       const imuBias::ConstantBias& bias_i, const imuBias::ConstantBias& bias_j,
-      OptionalMatrixType H1 = OptionalNone, 
-      OptionalMatrixType H2 = OptionalNone, 
-      OptionalMatrixType H3 = OptionalNone,
-      OptionalMatrixType H4 = OptionalNone, 
-      OptionalMatrixType H5 = OptionalNone, 
-      OptionalMatrixType H6 = OptionalNone) const override;
+      OptionalMatrixType H1, OptionalMatrixType H2, 
+      OptionalMatrixType H3, OptionalMatrixType H4, 
+      OptionalMatrixType H5, OptionalMatrixType H6) const override;
 
  private:
   /** Serialization function */

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -324,10 +324,12 @@ public:
   Vector evaluateError(const Pose3& pose_i, const Vector3& vel_i,
       const Pose3& pose_j, const Vector3& vel_j,
       const imuBias::ConstantBias& bias_i, const imuBias::ConstantBias& bias_j,
-      boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 =
-          boost::none, boost::optional<Matrix&> H3 = boost::none,
-      boost::optional<Matrix&> H4 = boost::none, boost::optional<Matrix&> H5 =
-          boost::none, boost::optional<Matrix&> H6 = boost::none) const override;
+      OptionalMatrixType H1 = OptionalNone, 
+      OptionalMatrixType H2 = OptionalNone, 
+      OptionalMatrixType H3 = OptionalNone,
+      OptionalMatrixType H4 = OptionalNone, 
+      OptionalMatrixType H5 = OptionalNone, 
+      OptionalMatrixType H6 = OptionalNone) const override;
 
  private:
   /** Serialization function */

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -268,6 +268,7 @@ private:
   PreintegratedCombinedMeasurements _PIM_;
 
 public:
+  // Provide access to Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */

--- a/gtsam/navigation/CombinedImuFactor.h
+++ b/gtsam/navigation/CombinedImuFactor.h
@@ -268,6 +268,7 @@ private:
   PreintegratedCombinedMeasurements _PIM_;
 
 public:
+
   // Provide access to Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -30,7 +30,8 @@ class ConstantVelocityFactor : public NoiseModelFactorN<NavState, NavState> {
     double dt_;
 
    public:
-    using Base = NoiseModelFactorN<NavState, NavState>;
+    using Base = NoiseModelFactor2<NavState, NavState>;
+    using Base::evaluateError;
 
    public:
     ConstantVelocityFactor(Key i, Key j, double dt, const SharedNoiseModel &model)
@@ -48,8 +49,7 @@ class ConstantVelocityFactor : public NoiseModelFactorN<NavState, NavState> {
      * @return * Vector
      */
     gtsam::Vector evaluateError(const NavState &x1, const NavState &x2,
-                                OptionalMatrixType H1 = OptionalNone,
-                                OptionalMatrixType H2 = OptionalNone) const override {
+                                OptionalMatrixType H1, OptionalMatrixType H2) const override {
         // only used to use update() below
         static const Vector3 b_accel{0.0, 0.0, 0.0};
         static const Vector3 b_omega{0.0, 0.0, 0.0};

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -31,6 +31,7 @@ class ConstantVelocityFactor : public NoiseModelFactorN<NavState, NavState> {
 
    public:
     using Base = NoiseModelFactor2<NavState, NavState>;
+
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -31,6 +31,7 @@ class ConstantVelocityFactor : public NoiseModelFactorN<NavState, NavState> {
 
    public:
     using Base = NoiseModelFactor2<NavState, NavState>;
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
    public:

--- a/gtsam/navigation/ConstantVelocityFactor.h
+++ b/gtsam/navigation/ConstantVelocityFactor.h
@@ -48,8 +48,8 @@ class ConstantVelocityFactor : public NoiseModelFactorN<NavState, NavState> {
      * @return * Vector
      */
     gtsam::Vector evaluateError(const NavState &x1, const NavState &x2,
-                                boost::optional<gtsam::Matrix &> H1 = boost::none,
-                                boost::optional<gtsam::Matrix &> H2 = boost::none) const override {
+                                OptionalMatrixType H1 = OptionalNone,
+                                OptionalMatrixType H2 = OptionalNone) const override {
         // only used to use update() below
         static const Vector3 b_accel{0.0, 0.0, 0.0};
         static const Vector3 b_omega{0.0, 0.0, 0.0};

--- a/gtsam/navigation/GPSFactor.cpp
+++ b/gtsam/navigation/GPSFactor.cpp
@@ -38,7 +38,7 @@ bool GPSFactor::equals(const NonlinearFactor& expected, double tol) const {
 
 //***************************************************************************
 Vector GPSFactor::evaluateError(const Pose3& p,
-    boost::optional<Matrix&> H) const {
+    OptionalMatrixType H) const {
   return p.translation(H) -nT_;
 }
 

--- a/gtsam/navigation/GPSFactor.cpp
+++ b/gtsam/navigation/GPSFactor.cpp
@@ -80,7 +80,7 @@ bool GPSFactor2::equals(const NonlinearFactor& expected, double tol) const {
 
 //***************************************************************************
 Vector GPSFactor2::evaluateError(const NavState& p,
-    boost::optional<Matrix&> H) const {
+    OptionalMatrixType H) const {
   return p.position(H) -nT_;
 }
 

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -152,7 +152,7 @@ public:
 
   /// vector of errors
   Vector evaluateError(const NavState& p,
-      boost::optional<Matrix&> H = boost::none) const override;
+      OptionalMatrixType H = OptionalNone) const override;
 
   inline const Point3 & measurementIn() const {
     return nT_;

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -44,6 +44,7 @@ public:
 
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<GPSFactor> shared_ptr;
 

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -122,6 +122,7 @@ private:
   Point3 nT_; ///< Position measurement in cartesian coordinates
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -42,6 +42,7 @@ private:
 
 public:
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<GPSFactor> shared_ptr;
@@ -120,6 +121,7 @@ private:
   Point3 nT_; ///< Position measurement in cartesian coordinates
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// shorthand for a smart pointer to a factor

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -79,7 +79,7 @@ public:
 
   /// vector of errors
   Vector evaluateError(const Pose3& p,
-      boost::optional<Matrix&> H = boost::none) const override;
+      OptionalMatrixType H = OptionalNone) const override;
 
   inline const Point3 & measurementIn() const {
     return nT_;

--- a/gtsam/navigation/GPSFactor.h
+++ b/gtsam/navigation/GPSFactor.h
@@ -42,6 +42,7 @@ private:
 
 public:
 
+  using Base::evaluateError;
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<GPSFactor> shared_ptr;
 
@@ -78,8 +79,7 @@ public:
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
 
   /// vector of errors
-  Vector evaluateError(const Pose3& p,
-      OptionalMatrixType H = OptionalNone) const override;
+  Vector evaluateError(const Pose3& p, OptionalMatrixType H) const override;
 
   inline const Point3 & measurementIn() const {
     return nT_;
@@ -120,6 +120,7 @@ private:
   Point3 nT_; ///< Position measurement in cartesian coordinates
 
 public:
+  using Base::evaluateError;
 
   /// shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<GPSFactor2> shared_ptr;
@@ -151,8 +152,7 @@ public:
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
 
   /// vector of errors
-  Vector evaluateError(const NavState& p,
-      OptionalMatrixType H = OptionalNone) const override;
+  Vector evaluateError(const NavState& p, OptionalMatrixType H) const override;
 
   inline const Point3 & measurementIn() const {
     return nT_;

--- a/gtsam/navigation/ImuFactor.cpp
+++ b/gtsam/navigation/ImuFactor.cpp
@@ -151,9 +151,9 @@ bool ImuFactor::equals(const NonlinearFactor& other, double tol) const {
 //------------------------------------------------------------------------------
 Vector ImuFactor::evaluateError(const Pose3& pose_i, const Vector3& vel_i,
     const Pose3& pose_j, const Vector3& vel_j,
-    const imuBias::ConstantBias& bias_i, boost::optional<Matrix&> H1,
-    boost::optional<Matrix&> H2, boost::optional<Matrix&> H3,
-    boost::optional<Matrix&> H4, boost::optional<Matrix&> H5) const {
+    const imuBias::ConstantBias& bias_i, OptionalMatrixType H1,
+    OptionalMatrixType H2, OptionalMatrixType H3,
+    OptionalMatrixType H4, OptionalMatrixType H5) const {
   return _PIM_.computeErrorAndJacobians(pose_i, vel_i, pose_j, vel_j, bias_i,
       H1, H2, H3, H4, H5);
 }
@@ -247,8 +247,8 @@ bool ImuFactor2::equals(const NonlinearFactor& other, double tol) const {
 Vector ImuFactor2::evaluateError(const NavState& state_i,
     const NavState& state_j,
     const imuBias::ConstantBias& bias_i, //
-    boost::optional<Matrix&> H1, boost::optional<Matrix&> H2,
-    boost::optional<Matrix&> H3) const {
+    OptionalMatrixType H1, OptionalMatrixType H2,
+    OptionalMatrixType H3) const {
   return _PIM_.computeError(state_i, state_j, bias_i, H1, H2, H3);
 }
 

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -228,10 +228,10 @@ public:
   /// vector of errors
   Vector evaluateError(const Pose3& pose_i, const Vector3& vel_i,
       const Pose3& pose_j, const Vector3& vel_j,
-      const imuBias::ConstantBias& bias_i, boost::optional<Matrix&> H1 =
-          boost::none, boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none, boost::optional<Matrix&> H4 =
-          boost::none, boost::optional<Matrix&> H5 = boost::none) const override;
+      const imuBias::ConstantBias& bias_i, OptionalMatrixType H1 =
+          OptionalNone, OptionalMatrixType H2 = OptionalNone,
+      OptionalMatrixType H3 = OptionalNone, OptionalMatrixType H4 =
+          OptionalNone, OptionalMatrixType H5 = OptionalNone) const override;
 
 #ifdef GTSAM_TANGENT_PREINTEGRATION
   /// Merge two pre-integrated measurement classes
@@ -307,9 +307,9 @@ public:
   /// vector of errors
   Vector evaluateError(const NavState& state_i, const NavState& state_j,
                        const imuBias::ConstantBias& bias_i,  //
-                       boost::optional<Matrix&> H1 = boost::none,
-                       boost::optional<Matrix&> H2 = boost::none,
-                       boost::optional<Matrix&> H3 = boost::none) const override;
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone,
+                       OptionalMatrixType H3 = OptionalNone) const override;
 
 private:
 

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -179,6 +179,7 @@ private:
   PreintegratedImuMeasurements _PIM_;
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -270,6 +270,9 @@ private:
 
 public:
 
+  // Provide access to the Matrix& version of evaluateError:
+  using Base::evaluateError;
+
   /** Default constructor - only use for serialization */
   ImuFactor2() {}
 

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -229,10 +229,8 @@ public:
   /// vector of errors
   Vector evaluateError(const Pose3& pose_i, const Vector3& vel_i,
       const Pose3& pose_j, const Vector3& vel_j,
-      const imuBias::ConstantBias& bias_i, OptionalMatrixType H1 =
-          OptionalNone, OptionalMatrixType H2 = OptionalNone,
-      OptionalMatrixType H3 = OptionalNone, OptionalMatrixType H4 =
-          OptionalNone, OptionalMatrixType H5 = OptionalNone) const override;
+      const imuBias::ConstantBias& bias_i, OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3, OptionalMatrixType H4, OptionalMatrixType H5) const override;
 
 #ifdef GTSAM_TANGENT_PREINTEGRATION
   /// Merge two pre-integrated measurement classes
@@ -308,9 +306,8 @@ public:
   /// vector of errors
   Vector evaluateError(const NavState& state_i, const NavState& state_j,
                        const imuBias::ConstantBias& bias_i,  //
-                       OptionalMatrixType H1 = OptionalNone,
-                       OptionalMatrixType H2 = OptionalNone,
-                       OptionalMatrixType H3 = OptionalNone) const override;
+                       OptionalMatrixType H1, OptionalMatrixType H2,
+                       OptionalMatrixType H3) const override;
 
 private:
 

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -179,6 +179,7 @@ private:
   PreintegratedImuMeasurements _PIM_;
 
 public:
+  using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */
 #if !defined(_MSC_VER) && __GNUC__ == 4 && __GNUC_MINOR__ > 5

--- a/gtsam/navigation/ImuFactor.h
+++ b/gtsam/navigation/ImuFactor.h
@@ -179,6 +179,7 @@ private:
   PreintegratedImuMeasurements _PIM_;
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /** Shorthand for a smart pointer to a factor */

--- a/gtsam/navigation/MagFactor.h
+++ b/gtsam/navigation/MagFactor.h
@@ -37,6 +37,7 @@ class MagFactor: public NoiseModelFactorN<Rot2> {
   const Point3 bias_; ///< bias
 
 public:
+  // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor1<Rot2>::evaluateError;
 
   /**
@@ -94,7 +95,9 @@ class MagFactor1: public NoiseModelFactorN<Rot3> {
   const Point3 bias_; ///< bias
 
 public:
+  // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor1<Rot3>::evaluateError;
+
 
   /** Constructor */
   MagFactor1(Key key, const Point3& measured, double scale,
@@ -131,7 +134,9 @@ class MagFactor2: public NoiseModelFactorN<Point3, Point3> {
   const Rot3 bRn_; ///< The assumed known rotation from nav to body
 
 public:
+  // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor2<Point3, Point3>::evaluateError;
+
 
   /** Constructor */
   MagFactor2(Key key1, Key key2, const Point3& measured, const Rot3& nRb,
@@ -172,7 +177,9 @@ class MagFactor3: public NoiseModelFactorN<double, Unit3, Point3> {
   const Rot3 bRn_; ///< The assumed known rotation from nav to body
 
 public:
+  // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor3<double, Unit3, Point3>::evaluateError;
+
 
   /** Constructor */
   MagFactor3(Key key1, Key key2, Key key3, const Point3& measured,

--- a/gtsam/navigation/MagFactor.h
+++ b/gtsam/navigation/MagFactor.h
@@ -37,6 +37,7 @@ class MagFactor: public NoiseModelFactorN<Rot2> {
   const Point3 bias_; ///< bias
 
 public:
+  using NoiseModelFactor1<Rot2>::evaluateError;
 
   /**
    * Constructor of factor that estimates nav to body rotation bRn
@@ -74,8 +75,7 @@ public:
   /**
    * @brief vector of errors
    */
-  Vector evaluateError(const Rot2& nRb,
-      OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Rot2& nRb, OptionalMatrixType H) const override {
     // measured bM = nRb� * nM + b
     Point3 hx = unrotate(nRb, nM_, H) + bias_;
     return (hx - measured_);
@@ -94,6 +94,7 @@ class MagFactor1: public NoiseModelFactorN<Rot3> {
   const Point3 bias_; ///< bias
 
 public:
+  using NoiseModelFactor1<Rot3>::evaluateError;
 
   /** Constructor */
   MagFactor1(Key key, const Point3& measured, double scale,
@@ -112,8 +113,7 @@ public:
   /**
    * @brief vector of errors
    */
-  Vector evaluateError(const Rot3& nRb,
-      OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Rot3& nRb, OptionalMatrixType H) const override {
     // measured bM = nRb� * nM + b
     Point3 hx = nRb.unrotate(nM_, H, boost::none) + bias_;
     return (hx - measured_);
@@ -131,6 +131,7 @@ class MagFactor2: public NoiseModelFactorN<Point3, Point3> {
   const Rot3 bRn_; ///< The assumed known rotation from nav to body
 
 public:
+  using NoiseModelFactor2<Point3, Point3>::evaluateError;
 
   /** Constructor */
   MagFactor2(Key key1, Key key2, const Point3& measured, const Rot3& nRb,
@@ -151,8 +152,7 @@ public:
    * @param bias (unknown) 3D bias
    */
   Vector evaluateError(const Point3& nM, const Point3& bias,
-      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 =
-          OptionalNone) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     // measured bM = nRb� * nM + b, where b is unknown bias
     Point3 hx = bRn_.rotate(nM, OptionalNone, H1) + bias;
     if (H2)
@@ -172,6 +172,7 @@ class MagFactor3: public NoiseModelFactorN<double, Unit3, Point3> {
   const Rot3 bRn_; ///< The assumed known rotation from nav to body
 
 public:
+  using NoiseModelFactor3<double, Unit3, Point3>::evaluateError;
 
   /** Constructor */
   MagFactor3(Key key1, Key key2, Key key3, const Point3& measured,
@@ -192,9 +193,8 @@ public:
    * @param bias (unknown) 3D bias
    */
   Vector evaluateError(const double& scale, const Unit3& direction,
-      const Point3& bias, OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone, OptionalMatrixType H3 =
-          OptionalNone) const override {
+      const Point3& bias, OptionalMatrixType H1,
+      OptionalMatrixType H2, OptionalMatrixType H3) const override {
     // measured bM = nRb� * nM + b, where b is unknown bias
     Unit3 rotated = bRn_.rotate(direction, OptionalNone, H2);
     Point3 hx = scale * rotated.point3() + bias;

--- a/gtsam/navigation/MagFactor.h
+++ b/gtsam/navigation/MagFactor.h
@@ -37,6 +37,7 @@ class MagFactor: public NoiseModelFactorN<Rot2> {
   const Point3 bias_; ///< bias
 
 public:
+
   // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor1<Rot2>::evaluateError;
 
@@ -95,6 +96,7 @@ class MagFactor1: public NoiseModelFactorN<Rot3> {
   const Point3 bias_; ///< bias
 
 public:
+
   // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor1<Rot3>::evaluateError;
 
@@ -134,6 +136,7 @@ class MagFactor2: public NoiseModelFactorN<Point3, Point3> {
   const Rot3 bRn_; ///< The assumed known rotation from nav to body
 
 public:
+
   // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor2<Point3, Point3>::evaluateError;
 
@@ -177,6 +180,7 @@ class MagFactor3: public NoiseModelFactorN<double, Unit3, Point3> {
   const Rot3 bRn_; ///< The assumed known rotation from nav to body
 
 public:
+
   // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor3<double, Unit3, Point3>::evaluateError;
 

--- a/gtsam/navigation/MagFactor.h
+++ b/gtsam/navigation/MagFactor.h
@@ -75,7 +75,7 @@ public:
    * @brief vector of errors
    */
   Vector evaluateError(const Rot2& nRb,
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     // measured bM = nRb� * nM + b
     Point3 hx = unrotate(nRb, nM_, H) + bias_;
     return (hx - measured_);
@@ -113,7 +113,7 @@ public:
    * @brief vector of errors
    */
   Vector evaluateError(const Rot3& nRb,
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     // measured bM = nRb� * nM + b
     Point3 hx = nRb.unrotate(nM_, H, boost::none) + bias_;
     return (hx - measured_);
@@ -151,10 +151,10 @@ public:
    * @param bias (unknown) 3D bias
    */
   Vector evaluateError(const Point3& nM, const Point3& bias,
-      boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 =
-          boost::none) const override {
+      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 =
+          OptionalNone) const override {
     // measured bM = nRb� * nM + b, where b is unknown bias
-    Point3 hx = bRn_.rotate(nM, boost::none, H1) + bias;
+    Point3 hx = bRn_.rotate(nM, OptionalNone, H1) + bias;
     if (H2)
       *H2 = I_3x3;
     return (hx - measured_);
@@ -192,11 +192,11 @@ public:
    * @param bias (unknown) 3D bias
    */
   Vector evaluateError(const double& scale, const Unit3& direction,
-      const Point3& bias, boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none, boost::optional<Matrix&> H3 =
-          boost::none) const override {
+      const Point3& bias, OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone, OptionalMatrixType H3 =
+          OptionalNone) const override {
     // measured bM = nRb� * nM + b, where b is unknown bias
-    Unit3 rotated = bRn_.rotate(direction, boost::none, H2);
+    Unit3 rotated = bRn_.rotate(direction, OptionalNone, H2);
     Point3 hx = scale * rotated.point3() + bias;
     if (H1)
       *H1 = rotated.point3();

--- a/gtsam/navigation/MagFactor.h
+++ b/gtsam/navigation/MagFactor.h
@@ -62,7 +62,7 @@ public:
   }
 
   static Point3 unrotate(const Rot2& R, const Point3& p,
-      boost::optional<Matrix&> HR = boost::none) {
+      OptionalMatrixType HR = OptionalNone) {
     Point3 q = Rot3::Yaw(R.theta()).unrotate(p, HR, boost::none);
     if (HR) {
       // assign to temporary first to avoid error in Win-Debug mode
@@ -115,7 +115,7 @@ public:
    */
   Vector evaluateError(const Rot3& nRb, OptionalMatrixType H) const override {
     // measured bM = nRb� * nM + b
-    Point3 hx = nRb.unrotate(nM_, H, boost::none) + bias_;
+    Point3 hx = nRb.unrotate(nM_, H, OptionalNone) + bias_;
     return (hx - measured_);
   }
 };

--- a/gtsam/navigation/MagPoseFactor.h
+++ b/gtsam/navigation/MagPoseFactor.h
@@ -49,6 +49,8 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
   GTSAM_CONCEPT_POSE_TYPE(POSE)
 
  public:
+  using Base::evaluateError;
+
   ~MagPoseFactor() override {}
 
   /// Default constructor - only use for serialization.
@@ -108,7 +110,7 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
    * Return the factor's error h(x) - z, and the optional Jacobian. Note that
    * the measurement error is expressed in the body frame.
    */
-  Vector evaluateError(const POSE& nPb, OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const POSE& nPb, OptionalMatrixType H) const override {
     // Predict the measured magnetic field h(x) in the *body* frame.
     // If body_P_sensor was given, bias_ will have been rotated into the body frame.
     Matrix H_rot = Matrix::Zero(MeasDim, RotDim);

--- a/gtsam/navigation/MagPoseFactor.h
+++ b/gtsam/navigation/MagPoseFactor.h
@@ -108,11 +108,11 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
    * Return the factor's error h(x) - z, and the optional Jacobian. Note that
    * the measurement error is expressed in the body frame.
    */
-  Vector evaluateError(const POSE& nPb, boost::optional<Matrix&> H = boost::none) const override {
+  Vector evaluateError(const POSE& nPb, OptionalMatrixType H = OptionalNone) const override {
     // Predict the measured magnetic field h(x) in the *body* frame.
     // If body_P_sensor was given, bias_ will have been rotated into the body frame.
     Matrix H_rot = Matrix::Zero(MeasDim, RotDim);
-    const Point hx = nPb.rotation().unrotate(nM_, H_rot, boost::none) + bias_;
+    const Point hx = nPb.rotation().unrotate(nM_, H_rot, OptionalNone) + bias_;
 
     if (H) {
       // Fill in the relevant part of the Jacobian (just rotation columns).

--- a/gtsam/navigation/MagPoseFactor.h
+++ b/gtsam/navigation/MagPoseFactor.h
@@ -49,6 +49,7 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
   GTSAM_CONCEPT_POSE_TYPE(POSE)
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/navigation/MagPoseFactor.h
+++ b/gtsam/navigation/MagPoseFactor.h
@@ -49,6 +49,7 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
   GTSAM_CONCEPT_POSE_TYPE(POSE)
 
  public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   ~MagPoseFactor() override {}

--- a/gtsam/navigation/MagPoseFactor.h
+++ b/gtsam/navigation/MagPoseFactor.h
@@ -52,6 +52,7 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   ~MagPoseFactor() override {}
 
   /// Default constructor - only use for serialization.

--- a/gtsam/navigation/MagPoseFactor.h
+++ b/gtsam/navigation/MagPoseFactor.h
@@ -53,7 +53,6 @@ class MagPoseFactor: public NoiseModelFactorN<POSE> {
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   ~MagPoseFactor() override {}
 
   /// Default constructor - only use for serialization.

--- a/gtsam/navigation/tests/testAttitudeFactor.cpp
+++ b/gtsam/navigation/tests/testAttitudeFactor.cpp
@@ -102,8 +102,8 @@ TEST( Pose3AttitudeFactor, Constructor ) {
 
   Matrix actualH1;
 
-  std::function<Vector(const Pose3&)> err_fn = [&factor](const Pose3& p){
-	return factor.evaluateError(p, OptionalNone);
+  auto err_fn = [&factor](const Pose3& p){
+    return factor.evaluateError(p, OptionalNone);
   };
   // Calculate numerical derivatives
   Matrix expectedH = numericalDerivative11<Vector,Pose3>(err_fn, T);

--- a/gtsam/navigation/tests/testAttitudeFactor.cpp
+++ b/gtsam/navigation/tests/testAttitudeFactor.cpp
@@ -49,8 +49,8 @@ TEST( Rot3AttitudeFactor, Constructor ) {
   Rot3 nRb;
   EXPECT(assert_equal((Vector) Z_2x1,factor.evaluateError(nRb),1e-5));
 
-  std::function<Vector(const Rot3&)> err_fn = [&factor](const Rot3& r){
-	return factor.evaluateError(r, OptionalNone);
+  auto err_fn = [&factor](const Rot3& r){
+    return factor.evaluateError(r, OptionalNone);
   };
   // Calculate numerical derivatives
   Matrix expectedH = numericalDerivative11<Vector, Rot3>(err_fn, nRb);

--- a/gtsam/navigation/tests/testAttitudeFactor.cpp
+++ b/gtsam/navigation/tests/testAttitudeFactor.cpp
@@ -21,6 +21,8 @@
 #include <gtsam/base/numericalDerivative.h>
 
 #include <boost/bind/bind.hpp>
+#include <functional>
+#include "gtsam/base/Matrix.h"
 #include <CppUnitLite/TestHarness.h>
 
 using namespace std::placeholders;
@@ -47,11 +49,11 @@ TEST( Rot3AttitudeFactor, Constructor ) {
   Rot3 nRb;
   EXPECT(assert_equal((Vector) Z_2x1,factor.evaluateError(nRb),1e-5));
 
+  std::function<Vector(const Rot3&)> err_fn = [&factor](const Rot3& r){
+	return factor.evaluateError(r, OptionalNone);
+  };
   // Calculate numerical derivatives
-  Matrix expectedH = numericalDerivative11<Vector, Rot3>(
-      std::bind(&Rot3AttitudeFactor::evaluateError, &factor,
-                std::placeholders::_1, boost::none),
-      nRb);
+  Matrix expectedH = numericalDerivative11<Vector, Rot3>(err_fn, nRb);
 
   // Use the factor to calculate the derivative
   Matrix actualH;
@@ -98,10 +100,13 @@ TEST( Pose3AttitudeFactor, Constructor ) {
   Pose3 T(Rot3(), Point3(-5.0, 8.0, -11.0));
   EXPECT(assert_equal((Vector) Z_2x1,factor.evaluateError(T),1e-5));
 
+  Matrix actualH1;
+
+  std::function<Vector(const Pose3&)> err_fn = [&factor](const Pose3& p){
+	return factor.evaluateError(p, OptionalNone);
+  };
   // Calculate numerical derivatives
-  Matrix expectedH = numericalDerivative11<Vector,Pose3>(
-      std::bind(&Pose3AttitudeFactor::evaluateError, &factor, std::placeholders::_1,
-          boost::none), T);
+  Matrix expectedH = numericalDerivative11<Vector,Pose3>(err_fn, T);
 
   // Use the factor to calculate the derivative
   Matrix actualH;

--- a/gtsam/navigation/tests/testBarometricFactor.cpp
+++ b/gtsam/navigation/tests/testBarometricFactor.cpp
@@ -58,15 +58,11 @@ TEST(BarometricFactor, Constructor) {
 
     // Calculate numerical derivatives
     Matrix expectedH = numericalDerivative21<Vector, Pose3, double>(
-        std::bind(&BarometricFactor::evaluateError, &factor,
-                  std::placeholders::_1, std::placeholders::_2, boost::none,
-                  boost::none),
-        T, baroBias);
+        [&factor](const Pose3& p, const double& d) {return factor.evaluateError(p, d);},
+		T, baroBias);
 
     Matrix expectedH2 = numericalDerivative22<Vector, Pose3, double>(
-        std::bind(&BarometricFactor::evaluateError, &factor,
-                  std::placeholders::_1, std::placeholders::_2, boost::none,
-                  boost::none),
+        [&factor](const Pose3& p, const double& d) {return factor.evaluateError(p, d);},
         T, baroBias);
 
     // Use the factor to calculate the derivative
@@ -99,15 +95,11 @@ TEST(BarometricFactor, nonZero) {
 
     // Calculate numerical derivatives
     Matrix expectedH = numericalDerivative21<Vector, Pose3, double>(
-        std::bind(&BarometricFactor::evaluateError, &factor,
-                  std::placeholders::_1, std::placeholders::_2, boost::none,
-                  boost::none),
+        [&factor](const Pose3& p, const double& d) {return factor.evaluateError(p, d);},
         T, baroBias);
 
     Matrix expectedH2 = numericalDerivative22<Vector, Pose3, double>(
-        std::bind(&BarometricFactor::evaluateError, &factor,
-                  std::placeholders::_1, std::placeholders::_2, boost::none,
-                  boost::none),
+        [&factor](const Pose3& p, const double& d) {return factor.evaluateError(p, d);},
         T, baroBias);
 
     // Use the factor to calculate the derivative and the error

--- a/gtsam/navigation/tests/testGPSFactor.cpp
+++ b/gtsam/navigation/tests/testGPSFactor.cpp
@@ -20,8 +20,6 @@
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
 
-#include <boost/bind/bind.hpp>
-
 #include <CppUnitLite/TestHarness.h>
 
 #include <GeographicLib/Config.h>
@@ -71,7 +69,7 @@ TEST( GPSFactor, Constructor ) {
 
   // Calculate numerical derivatives
   Matrix expectedH = numericalDerivative11<Vector, Pose3>(
-      std::bind(&GPSFactor::evaluateError, &factor, std::placeholders::_1, boost::none), T);
+      [&factor](const Pose3& T) { return factor.evaluateError(T); }, T);
 
   // Use the factor to calculate the derivative
   Matrix actualH;
@@ -100,7 +98,7 @@ TEST( GPSFactor2, Constructor ) {
 
   // Calculate numerical derivatives
   Matrix expectedH = numericalDerivative11<Vector, NavState>(
-      std::bind(&GPSFactor2::evaluateError, &factor, std::placeholders::_1, boost::none), T);
+      [&factor](const NavState& T) { return factor.evaluateError(T); }, T);
 
   // Use the factor to calculate the derivative
   Matrix actualH;

--- a/gtsam/navigation/tests/testMagFactor.cpp
+++ b/gtsam/navigation/tests/testMagFactor.cpp
@@ -56,15 +56,13 @@ Unit3 dir(nM);
 SharedNoiseModel model = noiseModel::Isotropic::Sigma(3, 0.25);
 }  // namespace
 
-using boost::none;
-
 // *************************************************************************
 TEST( MagFactor, unrotate ) {
   Matrix H;
   Point3 expected(22735.5, 314.502, 44202.5);
-  EXPECT( assert_equal(expected, MagFactor::unrotate(theta,nM,H),1e-1));
+  EXPECT( assert_equal(expected, MagFactor::unrotate(theta,nM,&H),1e-1));
   EXPECT(assert_equal(numericalDerivative11<Point3, Rot2> //
-      (std::bind(&MagFactor::unrotate, std::placeholders::_1, nM, none), theta), H, 1e-6));
+      (std::bind(&MagFactor::unrotate, std::placeholders::_1, nM, OptionalNone), theta), H, 1e-6));
 }
 
 // *************************************************************************
@@ -75,37 +73,32 @@ TEST( MagFactor, Factors ) {
   // MagFactor
   MagFactor f(1, measured, s, dir, bias, model);
   EXPECT(assert_equal(Z_3x1,f.evaluateError(theta,H1),1e-5));
-  EXPECT(assert_equal((Matrix)numericalDerivative11<Vector, Rot2> //
-      (std::bind(&MagFactor::evaluateError, &f, std::placeholders::_1, none), theta), H1, 1e-7));
+  EXPECT(assert_equal((Matrix)numericalDerivative11<Vector, Rot2>
+        ([&f] (const Rot2& theta) { return f.evaluateError(theta); }, theta), H1, 1e-7));
 
   // MagFactor1
   MagFactor1 f1(1, measured, s, dir, bias, model);
   EXPECT(assert_equal(Z_3x1,f1.evaluateError(nRb,H1),1e-5));
-  EXPECT(assert_equal(numericalDerivative11<Vector, Rot3> //
-      (std::bind(&MagFactor1::evaluateError, &f1, std::placeholders::_1, none), nRb), H1, 1e-7));
+  EXPECT(assert_equal(numericalDerivative11<Vector, Rot3>
+      ([&f1] (const Rot3& nRb) { return f1.evaluateError(nRb); }, nRb), H1, 1e-7));
 
   // MagFactor2
   MagFactor2 f2(1, 2, measured, nRb, model);
   EXPECT(assert_equal(Z_3x1,f2.evaluateError(scaled,bias,H1,H2),1e-5));
   EXPECT(assert_equal(numericalDerivative11<Vector, Point3> //
-      (std::bind(&MagFactor2::evaluateError, &f2, std::placeholders::_1, bias, none, none), scaled),//
-      H1, 1e-7));
+      ([&f2] (const Point3& scaled) { return f2.evaluateError(scaled,bias); }, scaled), H1, 1e-7));
   EXPECT(assert_equal(numericalDerivative11<Vector, Point3> //
-      (std::bind(&MagFactor2::evaluateError, &f2, scaled, std::placeholders::_1, none, none), bias),//
-      H2, 1e-7));
+      ([&f2] (const Point3& bias) { return f2.evaluateError(scaled,bias); }, bias), H2, 1e-7));
 
   // MagFactor3
   MagFactor3 f3(1, 2, 3, measured, nRb, model);
   EXPECT(assert_equal(Z_3x1,f3.evaluateError(s,dir,bias,H1,H2,H3),1e-5));
   EXPECT(assert_equal((Matrix)numericalDerivative11<Vector,double> //
-      (std::bind(&MagFactor3::evaluateError, &f3, std::placeholders::_1, dir, bias, none, none, none), s),//
-      H1, 1e-7));
+      ([&f3] (double s) { return f3.evaluateError(s,dir,bias); }, s), H1, 1e-7));
   EXPECT(assert_equal(numericalDerivative11<Vector,Unit3> //
-      (std::bind(&MagFactor3::evaluateError, &f3, s, std::placeholders::_1, bias, none, none, none), dir),//
-      H2, 1e-7));
+      ([&f3] (const Unit3& dir) { return f3.evaluateError(s,dir,bias); }, dir), H2, 1e-7));
   EXPECT(assert_equal(numericalDerivative11<Vector,Point3> //
-      (std::bind(&MagFactor3::evaluateError, &f3, s, dir, std::placeholders::_1, none, none, none), bias),//
-      H3, 1e-7));
+      ([&f3] (const Point3& bias) { return f3.evaluateError(s,dir,bias); }, bias), H3, 1e-7));
 }
 
 // *************************************************************************

--- a/gtsam/navigation/tests/testMagPoseFactor.cpp
+++ b/gtsam/navigation/tests/testMagPoseFactor.cpp
@@ -78,8 +78,7 @@ TEST(MagPoseFactor, JacobianPose2) {
   MagPoseFactor<Pose2> f(Symbol('X', 0), measured2, scale, dir2, bias2, model2, boost::none);
   CHECK(gtsam::assert_equal(Z_2x1, f.evaluateError(n_P2_b, H2), 1e-5));
   CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose2>  //
-                            (std::bind(&MagPoseFactor<Pose2>::evaluateError, &f,
-                                       std::placeholders::_1, boost::none),
+                            ([&f] (const Pose2& p) {return f.evaluateError(p);},
                              n_P2_b),
                             H2, 1e-7));
 }
@@ -92,8 +91,7 @@ TEST(MagPoseFactor, JacobianPose3) {
   MagPoseFactor<Pose3> f(Symbol('X', 0), measured3, scale, dir3, bias3, model3, boost::none);
   CHECK(gtsam::assert_equal(Z_3x1, f.evaluateError(n_P3_b, H3), 1e-5));
   CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose3>  //
-                            (std::bind(&MagPoseFactor<Pose3>::evaluateError, &f,
-                                       std::placeholders::_1, boost::none),
+                            ([&f] (const Pose3& p) {return f.evaluateError(p);},
                              n_P3_b),
                             H3, 1e-7));
 }
@@ -109,7 +107,7 @@ TEST(MagPoseFactor, body_P_sensor2) {
   MagPoseFactor<Pose2> f = MagPoseFactor<Pose2>(Symbol('X', 0), sM, scale, dir2, bias2, model2, body_P2_sensor);
   CHECK(gtsam::assert_equal(Z_2x1, f.evaluateError(n_P2_b, H2), 1e-5));
   CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose2> //
-      (std::bind(&MagPoseFactor<Pose2>::evaluateError, &f, std::placeholders::_1, boost::none), n_P2_b), H2, 1e-7));
+      ([&f] (const Pose2& p) {return f.evaluateError(p);},n_P2_b), H2, 1e-7));
 }
 
 // *****************************************************************************
@@ -123,7 +121,7 @@ TEST(MagPoseFactor, body_P_sensor3) {
   MagPoseFactor<Pose3> f = MagPoseFactor<Pose3>(Symbol('X', 0), sM, scale, dir3, bias3, model3, body_P3_sensor);
   CHECK(gtsam::assert_equal(Z_3x1, f.evaluateError(n_P3_b, H3), 1e-5));
   CHECK(gtsam::assert_equal(gtsam::numericalDerivative11<Vector, Pose3> //
-      (std::bind(&MagPoseFactor<Pose3>::evaluateError, &f, std::placeholders::_1, boost::none), n_P3_b), H3, 1e-7));
+      ([&f] (const Pose3& p) {return f.evaluateError(p);}, n_P3_b), H3, 1e-7));
 }
 
 // *****************************************************************************

--- a/gtsam/nonlinear/CustomFactor.cpp
+++ b/gtsam/nonlinear/CustomFactor.cpp
@@ -43,7 +43,7 @@ Vector CustomFactor::unwhitenedError(const Values& x, OptionalMatrixVecType H) c
        *    return error
        * ```
        */
-      return this->error_function_(*this, x, &(*H));
+      return this->error_function_(*this, x, H);
     } else {
       /*
        * In this case, we pass the a `nullptr` to pybind, and it will translate to `None` in Python.

--- a/gtsam/nonlinear/CustomFactor.cpp
+++ b/gtsam/nonlinear/CustomFactor.cpp
@@ -22,7 +22,7 @@ namespace gtsam {
 /*
  * Calculates the unwhitened error by invoking the callback functor (i.e. from Python).
  */
-Vector CustomFactor::unwhitenedError(const Values& x, boost::optional<std::vector<Matrix>&> H) const {
+Vector CustomFactor::unwhitenedError(const Values& x, OptionalMatrixVecType H) const {
   if(this->active(x)) {
 
     if(H) {

--- a/gtsam/nonlinear/CustomFactor.cpp
+++ b/gtsam/nonlinear/CustomFactor.cpp
@@ -43,7 +43,7 @@ Vector CustomFactor::unwhitenedError(const Values& x, OptionalMatrixVecType H) c
        *    return error
        * ```
        */
-      return this->error_function_(*this, x, H.get_ptr());
+      return this->error_function_(*this, x, &(*H));
     } else {
       /*
        * In this case, we pass the a `nullptr` to pybind, and it will translate to `None` in Python.

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -75,7 +75,7 @@ public:
     * Calls the errorFunction closure, which is a std::function object
     * One can check if a derivative is needed in the errorFunction by checking the length of Jacobian array
     */
-  Vector unwhitenedError(const Values &x, OptionalMatrixVecType H = boost::none) const override;
+  Vector unwhitenedError(const Values &x, OptionalMatrixVecType H = OptionalMatrixVecNone) const override;
 
   /** print */
   void print(const std::string &s,

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -75,7 +75,7 @@ public:
     * Calls the errorFunction closure, which is a std::function object
     * One can check if a derivative is needed in the errorFunction by checking the length of Jacobian array
     */
-  Vector unwhitenedError(const Values &x, OptionalMatrixVecType H = OptionalMatrixVecNone) const override;
+  Vector unwhitenedError(const Values &x, OptionalMatrixVecType H = nullptr) const override;
 
   /** print */
   void print(const std::string &s,

--- a/gtsam/nonlinear/CustomFactor.h
+++ b/gtsam/nonlinear/CustomFactor.h
@@ -75,7 +75,7 @@ public:
     * Calls the errorFunction closure, which is a std::function object
     * One can check if a derivative is needed in the errorFunction by checking the length of Jacobian array
     */
-  Vector unwhitenedError(const Values &x, boost::optional<std::vector<Matrix> &> H = boost::none) const override;
+  Vector unwhitenedError(const Values &x, OptionalMatrixVecType H = boost::none) const override;
 
   /** print */
   void print(const std::string &s,

--- a/gtsam/nonlinear/Expression-inl.h
+++ b/gtsam/nonlinear/Expression-inl.h
@@ -138,8 +138,7 @@ void Expression<T>::print(const std::string& s) const {
 
 template<typename T>
 T Expression<T>::value(const Values& values,
-    boost::optional<std::vector<Matrix>&> H) const {
-
+    std::vector<Matrix>* H) const {
   if (H) {
     // Call private version that returns derivatives in H
     KeyVector keys;

--- a/gtsam/nonlinear/Expression.h
+++ b/gtsam/nonlinear/Expression.h
@@ -155,8 +155,15 @@ public:
    * Notes: this is not terribly efficient, and H should have correct size.
    * The order of the Jacobians is same as keys in either keys() or dims()
    */
-  T value(const Values& values, boost::optional<std::vector<Matrix>&> H =
-      boost::none) const;
+  T value(const Values& values, std::vector<Matrix>* H = nullptr) const;
+
+  /**
+   * An overload of the value function to accept reference to vector of matrices instead of
+   * a pointer to vector of matrices.
+   */
+  T value(const Values& values, std::vector<Matrix>& H) const {
+    return value(values, &H);
+  }
 
   /**
    *  @return a "deep" copy of this Expression

--- a/gtsam/nonlinear/ExpressionFactor.h
+++ b/gtsam/nonlinear/ExpressionFactor.h
@@ -97,7 +97,7 @@ protected:
    * both the function evaluation and its derivative(s) in H.
    */
   Vector unwhitenedError(const Values& x,
-    OptionalMatrixVecType H = OptionalNone) const override {
+    OptionalMatrixVecType H = OptionalMatrixVecNone) const override {
     if (H) {
       const T value = expression_.valueAndDerivatives(x, keys_, dims_, *H);
       // NOTE(hayk): Doing the reverse, AKA Local(measured_, value) is not correct here

--- a/gtsam/nonlinear/ExpressionFactor.h
+++ b/gtsam/nonlinear/ExpressionFactor.h
@@ -343,7 +343,8 @@ protected:
   ExpressionFactor2() {}
 
   /// Constructor takes care of keys, but still need to call initialize
-  ExpressionFactor2(Key key1, Key key2, const SharedNoiseModel& noiseModel, const T& measurement)
+  ExpressionFactor2(Key key1, Key key2, const SharedNoiseModel& noiseModel,
+                    const T &measurement)
       : ExpressionFactorN<T, A1, A2>({key1, key2}, noiseModel, measurement) {}
 };
 // ExpressionFactor2

--- a/gtsam/nonlinear/ExpressionFactor.h
+++ b/gtsam/nonlinear/ExpressionFactor.h
@@ -55,6 +55,7 @@ protected:
 
 
  public:
+  // Provide access to the Matrix& version of unwhitenedError:
   using NoiseModelFactor::unwhitenedError;
   typedef boost::shared_ptr<ExpressionFactor<T> > shared_ptr;
 
@@ -244,6 +245,8 @@ class ExpressionFactorN : public ExpressionFactor<T> {
 public:
   static const std::size_t NARY_EXPRESSION_SIZE = sizeof...(Args);
   using ArrayNKeys = std::array<Key, NARY_EXPRESSION_SIZE>;
+    
+  // Provide access to the Matrix& version of unwhitenedError:
   using ExpressionFactor<T>::unwhitenedError;
 
   /// Destructor

--- a/gtsam/nonlinear/ExpressionFactor.h
+++ b/gtsam/nonlinear/ExpressionFactor.h
@@ -55,6 +55,7 @@ protected:
 
 
  public:
+
   // Provide access to the Matrix& version of unwhitenedError:
   using NoiseModelFactor::unwhitenedError;
   typedef boost::shared_ptr<ExpressionFactor<T> > shared_ptr;

--- a/gtsam/nonlinear/ExpressionFactor.h
+++ b/gtsam/nonlinear/ExpressionFactor.h
@@ -28,6 +28,97 @@
 
 namespace gtsam {
 
+template <typename... ValueTypes>
+class EvaluateErrorInterface {
+public:
+  enum { N = sizeof...(ValueTypes) };
+
+private:
+  template <int I>
+  using IndexIsValid = typename std::enable_if<(I >= 1) && (I <= N),
+                                               void>::type;  // 1-indexed!
+
+public:
+  /**
+   * Override `evaluateError` to finish implementing an n-way factor.
+   *
+   * Both the `x` and `H` arguments are written here as parameter packs, but
+   * when overriding this method, you probably want to explicitly write them
+   * out.  For example, for a 2-way factor with variable types Pose3 and Point3,
+   * you should implement:
+   * ```
+   * Vector evaluateError(
+   *     const Pose3& x1, const Point3& x2,
+   *     boost::optional<Matrix&> H1 = boost::none,
+   *     boost::optional<Matrix&> H2 = boost::none) const override { ... }
+   * ```
+   *
+   * If any of the optional Matrix reference arguments are specified, it should
+   * compute both the function evaluation and its derivative(s) in the requested
+   * variables.
+   *
+   * @param x The values of the variables to evaluate the error for.  Passed in
+   * as separate arguments.
+   * @param[out] H The Jacobian with respect to each variable (optional).
+   */
+  virtual Vector evaluateError(const ValueTypes&... x, OptionalMatrixTypeT<ValueTypes>... H) const = 0;
+
+#ifdef NO_BOOST_CPP17
+  // if someone uses the evaluateError function by supplying all the optional
+  // arguments then redirect the call to the one which takes pointers
+  Vector evaluateError(const ValueTypes&... x, MatrixTypeT<ValueTypes>&... H) const {
+    return evaluateError(x..., (&H)...);
+  }
+#endif
+
+  /// @}
+  /// @name Convenience method overloads
+  /// @{
+
+  /** No-Jacobians requested function overload.
+   * This specializes the version below to avoid recursive calls since this is
+   * commonly used.
+   *
+   * e.g. `const Vector error = factor.evaluateError(pose, point);`
+   */
+  inline Vector evaluateError(const ValueTypes&... x) const {
+    return evaluateError(x..., OptionalMatrixTypeT<ValueTypes>()...);
+  }
+
+  /** Some (but not all) optional Jacobians are omitted (function overload)
+   *
+   * e.g. `const Vector error = factor.evaluateError(pose, point, Hpose);`
+   */
+  template <typename... OptionalJacArgs, typename = IndexIsValid<sizeof...(OptionalJacArgs) + 1>>
+  inline Vector evaluateError(const ValueTypes&... x, OptionalJacArgs&&... H) const {
+#ifdef NO_BOOST_CPP17
+    // A check to ensure all arguments passed are all either matrices or are all pointers to matrices
+    constexpr bool are_all_mat = (... && (std::is_same<Matrix, std::decay_t<OptionalJacArgs>>::value));
+    constexpr bool are_all_ptrs = (... && (std::is_same<OptionalMatrixType, std::decay_t<OptionalJacArgs>>::value ||
+                                           std::is_same<OptionalNoneType, std::decay_t<OptionalJacArgs>>::value));
+    static_assert((are_all_mat || are_all_ptrs),
+                  "Arguments that are passed to the evaluateError function can only be of following the types: Matrix, "
+                  "or Matrix*");
+    // if they pass all matrices then we want to pass their pointers instead
+    if constexpr (are_all_mat) {
+      return evaluateError(x..., (&H)...);
+    } else {
+      return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., static_cast<OptionalMatrixType>(OptionalNone));
+    }
+#else
+    // A check to ensure all arguments passed are all either matrices or are optionals of matrix references
+    constexpr bool are_all_mat = (... && (std::is_same<Matrix&, OptionalJacArgs>::value ||
+                                          std::is_same<OptionalMatrixType, std::decay_t<OptionalJacArgs>>::value ||
+                                          std::is_same<OptionalNoneType, std::decay_t<OptionalJacArgs>>::value));
+    static_assert(
+        are_all_mat,
+        "Arguments that are passed to the evaluateError function can only be of following the types: Matrix&, "
+        "boost::optional<Matrix&>, or boost::none_t");
+    return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., OptionalNone);
+#endif
+  }
+};
+
 /**
  * Factor that supports arbitrary expressions via AD.
  *
@@ -40,8 +131,8 @@ namespace gtsam {
  * \tparam T Type for measurements.
  *
  */
-template<typename T>
-class ExpressionFactor: public NoiseModelFactor {
+template <typename T>
+class ExpressionFactor : public NoiseModelFactor {
   BOOST_CONCEPT_ASSERT((IsTestable<T>));
 
 protected:
@@ -55,6 +146,7 @@ protected:
 
 
  public:
+  using NoiseModelFactor::unwhitenedError;
   typedef boost::shared_ptr<ExpressionFactor<T> > shared_ptr;
 
   /**
@@ -243,6 +335,7 @@ class ExpressionFactorN : public ExpressionFactor<T> {
 public:
   static const std::size_t NARY_EXPRESSION_SIZE = sizeof...(Args);
   using ArrayNKeys = std::array<Key, NARY_EXPRESSION_SIZE>;
+  using ExpressionFactor<T>::unwhitenedError;
 
   /// Destructor
   ~ExpressionFactorN() override = default;
@@ -305,15 +398,14 @@ struct traits<ExpressionFactorN<T, Args...>>
  * @deprecated Prefer the more general ExpressionFactorN<>.
  */
 template <typename T, typename A1, typename A2>
-class GTSAM_DEPRECATED ExpressionFactor2 : public ExpressionFactorN<T, A1, A2> {
+class GTSAM_DEPRECATED ExpressionFactor2 : public ExpressionFactorN<T, A1, A2>, public EvaluateErrorInterface<A1, A2> {
 public:
   /// Destructor
   ~ExpressionFactor2() override {}
 
   /// Backwards compatible evaluateError, to make existing tests compile
-  Vector evaluateError(const A1 &a1, const A2 &a2,
-                       OptionalMatrixType H1 = OptionalNone,
-                       OptionalMatrixType H2 = OptionalNone) const {
+  virtual Vector evaluateError(const A1& a1, const A2& a2, OptionalMatrixType H1,
+                               OptionalMatrixType H2) const override {
     Values values;
     values.insert(this->keys_[0], a1);
     values.insert(this->keys_[1], a2);
@@ -327,12 +419,9 @@ public:
   /// Recreate expression from given keys_ and measured_, used in load
   /// Needed to deserialize a derived factor
   virtual Expression<T> expression(Key key1, Key key2) const {
-    throw std::runtime_error(
-        "ExpressionFactor2::expression not provided: cannot deserialize.");
+    throw std::runtime_error("ExpressionFactor2::expression not provided: cannot deserialize.");
   }
-  Expression<T>
-  expression(const typename ExpressionFactorN<T, A1, A2>::ArrayNKeys &keys)
-      const override {
+  Expression<T> expression(const typename ExpressionFactorN<T, A1, A2>::ArrayNKeys& keys) const override {
     return expression(keys[0], keys[1]);
   }
 
@@ -341,8 +430,7 @@ protected:
   ExpressionFactor2() {}
 
   /// Constructor takes care of keys, but still need to call initialize
-  ExpressionFactor2(Key key1, Key key2, const SharedNoiseModel &noiseModel,
-                    const T &measurement)
+  ExpressionFactor2(Key key1, Key key2, const SharedNoiseModel& noiseModel, const T& measurement)
       : ExpressionFactorN<T, A1, A2>({key1, key2}, noiseModel, measurement) {}
 };
 // ExpressionFactor2

--- a/gtsam/nonlinear/ExpressionFactor.h
+++ b/gtsam/nonlinear/ExpressionFactor.h
@@ -97,7 +97,7 @@ protected:
    * both the function evaluation and its derivative(s) in H.
    */
   Vector unwhitenedError(const Values& x,
-    boost::optional<std::vector<Matrix>&> H = boost::none) const override {
+    OptionalMatrixVecType H = OptionalNone) const override {
     if (H) {
       const T value = expression_.valueAndDerivatives(x, keys_, dims_, *H);
       // NOTE(hayk): Doing the reverse, AKA Local(measured_, value) is not correct here
@@ -312,8 +312,8 @@ public:
 
   /// Backwards compatible evaluateError, to make existing tests compile
   Vector evaluateError(const A1 &a1, const A2 &a2,
-                       boost::optional<Matrix &> H1 = boost::none,
-                       boost::optional<Matrix &> H2 = boost::none) const {
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone) const {
     Values values;
     values.insert(this->keys_[0], a1);
     values.insert(this->keys_[1], a2);

--- a/gtsam/nonlinear/ExpressionFactor.h
+++ b/gtsam/nonlinear/ExpressionFactor.h
@@ -99,7 +99,7 @@ protected:
    * both the function evaluation and its derivative(s) in H.
    */
   Vector unwhitenedError(const Values& x,
-    OptionalMatrixVecType H = OptionalMatrixVecNone) const override {
+    OptionalMatrixVecType H = nullptr) const override {
     if (H) {
       const T value = expression_.valueAndDerivatives(x, keys_, dims_, *H);
       // NOTE(hayk): Doing the reverse, AKA Local(measured_, value) is not correct here

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -87,8 +87,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
         NonlinearFactor::shared_ptr(new FunctorizedFactor<R, T>(*this)));
   }
 
-  Vector evaluateError(const T &params, OptionalMatrixType H =
-                                            OptionalNone) const override {
+  Vector evaluateError(const T &params, OptionalMatrixType H) const override {
     R x = func_(params, H);
     Vector error = traits<R>::Local(measured_, x);
     return error;
@@ -193,8 +192,7 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
 
   Vector evaluateError(
       const T1 &params1, const T2 &params2,
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     R x = func_(params1, params2, H1, H2);
     Vector error = traits<R>::Local(measured_, x);
     return error;

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -65,6 +65,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
   std::function<R(T, OptionalMatrixType)> func_;  ///< functor instance
 
  public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /** default constructor - only use for serialization */
   FunctorizedFactor() {}
@@ -166,6 +167,7 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
   FunctionType func_;  ///< functor instance
 
  public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /** default constructor - only use for serialization */
   FunctorizedFactor2() {}

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -67,6 +67,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
  public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /** default constructor - only use for serialization */
   FunctorizedFactor() {}
 
@@ -169,6 +170,7 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
  public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /** default constructor - only use for serialization */
   FunctorizedFactor2() {}
 

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -62,7 +62,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
 
   R measured_;  ///< value that is compared with functor return value
   SharedNoiseModel noiseModel_;                          ///< noise model
-  std::function<R(T, boost::optional<Matrix &>)> func_;  ///< functor instance
+  std::function<R(T, OptionalMatrixType)> func_;  ///< functor instance
 
  public:
   /** default constructor - only use for serialization */
@@ -76,7 +76,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
    * @param func: The instance of the functor object
    */
   FunctorizedFactor(Key key, const R &z, const SharedNoiseModel &model,
-                    const std::function<R(T, boost::optional<Matrix &>)> func)
+                    const std::function<R(T, OptionalMatrixType)> func)
       : Base(model, key), measured_(z), noiseModel_(model), func_(func) {}
 
   ~FunctorizedFactor() override {}
@@ -87,8 +87,8 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
         NonlinearFactor::shared_ptr(new FunctorizedFactor<R, T>(*this)));
   }
 
-  Vector evaluateError(const T &params, boost::optional<Matrix &> H =
-                                            boost::none) const override {
+  Vector evaluateError(const T &params, OptionalMatrixType H =
+                                            OptionalNone) const override {
     R x = func_(params, H);
     Vector error = traits<R>::Local(measured_, x);
     return error;
@@ -162,8 +162,7 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
 
   R measured_;  ///< value that is compared with functor return value
   SharedNoiseModel noiseModel_;  ///< noise model
-  using FunctionType = std::function<R(T1, T2, boost::optional<Matrix &>,
-                                       boost::optional<Matrix &>)>;
+  using FunctionType = std::function<R(T1, T2, OptionalMatrixType, OptionalMatrixType)>;
   FunctionType func_;  ///< functor instance
 
  public:
@@ -194,8 +193,8 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
 
   Vector evaluateError(
       const T1 &params1, const T2 &params2,
-      boost::optional<Matrix &> H1 = boost::none,
-      boost::optional<Matrix &> H2 = boost::none) const override {
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const override {
     R x = func_(params1, params2, H1, H2);
     Vector error = traits<R>::Local(measured_, x);
     return error;

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -65,6 +65,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
   std::function<R(T, OptionalMatrixType)> func_;  ///< functor instance
 
  public:
+  using Base::evaluateError;
   /** default constructor - only use for serialization */
   FunctorizedFactor() {}
 
@@ -165,6 +166,7 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
   FunctionType func_;  ///< functor instance
 
  public:
+  using Base::evaluateError;
   /** default constructor - only use for serialization */
   FunctorizedFactor2() {}
 

--- a/gtsam/nonlinear/FunctorizedFactor.h
+++ b/gtsam/nonlinear/FunctorizedFactor.h
@@ -65,6 +65,7 @@ class FunctorizedFactor : public NoiseModelFactorN<T> {
   std::function<R(T, OptionalMatrixType)> func_;  ///< functor instance
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -168,6 +169,7 @@ class FunctorizedFactor2 : public NoiseModelFactorN<T1, T2> {
   FunctionType func_;  ///< functor instance
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/nonlinear/ISAM2.cpp
+++ b/gtsam/nonlinear/ISAM2.cpp
@@ -478,8 +478,8 @@ ISAM2Result ISAM2::update(const NonlinearFactorGraph& newFactors,
 /* ************************************************************************* */
 void ISAM2::marginalizeLeaves(
     const FastList<Key>& leafKeysList,
-    boost::optional<FactorIndices&> marginalFactorsIndices,
-    boost::optional<FactorIndices&> deletedFactorsIndices) {
+    FactorIndices* marginalFactorsIndices,
+    FactorIndices* deletedFactorsIndices) {
   // Convert to ordered set
   KeySet leafKeys(leafKeysList.begin(), leafKeysList.end());
 

--- a/gtsam/nonlinear/ISAM2.h
+++ b/gtsam/nonlinear/ISAM2.h
@@ -198,8 +198,20 @@ class GTSAM_EXPORT ISAM2 : public BayesTree<ISAM2Clique> {
    */
   void marginalizeLeaves(
       const FastList<Key>& leafKeys,
-      boost::optional<FactorIndices&> marginalFactorsIndices = boost::none,
-      boost::optional<FactorIndices&> deletedFactorsIndices = boost::none);
+      FactorIndices* marginalFactorsIndices = nullptr,
+      FactorIndices* deletedFactorsIndices = nullptr);
+
+  /** An overload of marginalizeLeaves that takes references
+   * to vectors instead of pointers to vectors and passes
+   * it to the pointer version of the function.
+   */
+  template <class... OptArgs>
+      void marginalizeLeaves(const FastList<Key>& leafKeys,
+                             OptArgs&&... optArgs) {
+          // dereference the optional arguments and pass
+          // it to the pointer version
+          marginalizeLeaves(leafKeys, (&optArgs)...);
+      }
 
   /// Access the current linearization point
   const Values& getLinearizationPoint() const { return theta_; }

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -139,7 +139,7 @@ public:
 
   /// Error function
   Vector evaluateError(const T& xj,
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     const size_t nj = traits<T>::GetDimension(feasible_);
     if (allow_error_) {
       if (H)
@@ -249,7 +249,7 @@ public:
 
   /// g(x) with optional derivative
   Vector evaluateError(const X& x1,
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     if (H)
       (*H) = Matrix::Identity(traits<X>::GetDimension(x1),traits<X>::GetDimension(x1));
     // manifold equivalent of h(x)-z -> log(z,h(x))
@@ -324,8 +324,8 @@ class NonlinearEquality2 : public NoiseModelFactorN<T, T> {
 
   /// g(x) with optional derivative2
   Vector evaluateError(
-      const T& x1, const T& x2, boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override {
+      const T& x1, const T& x2, OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const override {
     static const size_t p = traits<T>::dimension;
     if (H1) *H1 = -Matrix::Identity(p, p);
     if (H2) *H2 = Matrix::Identity(p, p);

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -46,6 +46,7 @@ class NonlinearEquality: public NoiseModelFactorN<VALUE> {
 
 public:
   typedef VALUE T;
+  using NoiseModelFactor1<VALUE>::evaluateError;
 
 private:
 

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -46,6 +46,7 @@ class NonlinearEquality: public NoiseModelFactorN<VALUE> {
 
 public:
   typedef VALUE T;
+  // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor1<VALUE>::evaluateError;
 
 private:

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -209,6 +209,8 @@ class NonlinearEquality1: public NoiseModelFactorN<VALUE> {
 
 public:
   typedef VALUE X;
+
+  // Provide access to Matrix& version of evaluateError:
   using NoiseModelFactor1<VALUE>::evaluateError;
 
 protected:
@@ -307,6 +309,7 @@ class NonlinearEquality2 : public NoiseModelFactorN<T, T> {
   typedef boost::shared_ptr<NonlinearEquality2<T>> shared_ptr;
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
 
   /**
    * Constructor

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -46,6 +46,7 @@ class NonlinearEquality: public NoiseModelFactorN<VALUE> {
 
 public:
   typedef VALUE T;
+
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor1<VALUE>::evaluateError;
 
@@ -307,6 +308,7 @@ class NonlinearEquality2 : public NoiseModelFactorN<T, T> {
 
  public:
   typedef boost::shared_ptr<NonlinearEquality2<T>> shared_ptr;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -139,8 +139,7 @@ public:
   }
 
   /// Error function
-  Vector evaluateError(const T& xj,
-      OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const T& xj, OptionalMatrixType H) const override {
     const size_t nj = traits<T>::GetDimension(feasible_);
     if (allow_error_) {
       if (H)
@@ -209,6 +208,7 @@ class NonlinearEquality1: public NoiseModelFactorN<VALUE> {
 
 public:
   typedef VALUE X;
+  using NoiseModelFactor1<VALUE>::evaluateError;
 
 protected:
   typedef NoiseModelFactorN<VALUE> Base;
@@ -249,8 +249,7 @@ public:
   }
 
   /// g(x) with optional derivative
-  Vector evaluateError(const X& x1,
-      OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const X& x1, OptionalMatrixType H) const override {
     if (H)
       (*H) = Matrix::Identity(traits<X>::GetDimension(x1),traits<X>::GetDimension(x1));
     // manifold equivalent of h(x)-z -> log(z,h(x))
@@ -305,6 +304,7 @@ class NonlinearEquality2 : public NoiseModelFactorN<T, T> {
 
  public:
   typedef boost::shared_ptr<NonlinearEquality2<T>> shared_ptr;
+  using Base::evaluateError;
 
   /**
    * Constructor
@@ -325,8 +325,7 @@ class NonlinearEquality2 : public NoiseModelFactorN<T, T> {
 
   /// g(x) with optional derivative2
   Vector evaluateError(
-      const T& x1, const T& x2, OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const override {
+      const T& x1, const T& x2, OptionalMatrixType H1, OptionalMatrixType H2) const override {
     static const size_t p = traits<T>::dimension;
     if (H1) *H1 = -Matrix::Identity(p, p);
     if (H2) *H2 = Matrix::Identity(p, p);

--- a/gtsam/nonlinear/NonlinearEquality.h
+++ b/gtsam/nonlinear/NonlinearEquality.h
@@ -305,6 +305,7 @@ class NonlinearEquality2 : public NoiseModelFactorN<T, T> {
 
  public:
   typedef boost::shared_ptr<NonlinearEquality2<T>> shared_ptr;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /**

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -381,8 +381,8 @@ struct NoiseModelFactorAliases<T1, T2, T3, T4, T5, T6, TExtra...> {
  *
  *   Vector evaluateError(
  *       const Pose3& T, const Point3& p,
- *       boost::optional<Matrix&> H_T = boost::none,
- *       boost::optional<Matrix&> H_p = boost::none) const override {
+ *       OptionalMatrixType H_T = OptionalNone,
+ *       OptionalMatrixType H_p = OptionalNone) const override {
  *     Matrix36 t_H_T;  // partial derivative of translation w.r.t. pose T
  *
  *     // Only compute t_H_T if needed:
@@ -449,7 +449,7 @@ protected:
 
   /// @}
 
-  /* Like std::void_t, except produces `boost::optional<Matrix&>` instead of
+  /* Like std::void_t, except produces `OptionalMatrixType` instead of
    * `void`. Used to expand fixed-type parameter-packs with same length as
    * ValueTypes. */
 
@@ -582,8 +582,8 @@ protected:
    * ```
    * Vector evaluateError(
    *     const Pose3& x1, const Point3& x2,
-   *     boost::optional<Matrix&> H1 = boost::none,
-   *     boost::optional<Matrix&> H2 = boost::none) const override { ... }
+   *     OptionalMatrixType H1 = OptionalNone,
+   *     OptionalMatrixType H2 = OptionalNone) const override { ... }
    * ```
    *
    * If any of the optional Matrix reference arguments are specified, it should

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -35,7 +35,7 @@ namespace gtsam {
 
 /* ************************************************************************* */
 
-/* These typedefs and aliases will help with making the evaluateError interface
+/** These typedefs and aliases will help with making the evaluateError interface
 * independent of boost
 * TODO(kartikarcot): Change this to OptionalMatrixNone
 * This typedef is used to indicate that the Jacobian is not required
@@ -45,13 +45,13 @@ namespace gtsam {
 */
 #define OptionalNone static_cast<Matrix*>(nullptr)
 
-/* This typedef will be used everywhere boost::optional<Matrix&> reference was used
+/** This typedef will be used everywhere boost::optional<Matrix&> reference was used
  * previously. This is used to indicate that the Jacobian is optional. In the future
  * we will change this to OptionalJacobian
  */
 using OptionalMatrixType = Matrix*;
 
-/* The OptionalMatrixVecType is a pointer to a vector of matrices. It will
+/** The OptionalMatrixVecType is a pointer to a vector of matrices. It will
  * be used in situations where a vector of matrices is optional, like in 
  * unwhitenedError. */
 using OptionalMatrixVecType = std::vector<Matrix>*;
@@ -253,11 +253,11 @@ public:
    */
   virtual Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = nullptr) const = 0;
 
-  // support taking in the actual vector instead of the pointer as well
-  // to get access to this version of the function from derived classes
-  // one will need to use the "using" keyword and specify that like this:
-  // public:
-  //   using NoiseModelFactor::unwhitenedError;
+  /** support taking in the actual vector instead of the pointer as well
+  * to get access to this version of the function from derived classes
+  * one will need to use the "using" keyword and specify that like this:
+  * public:
+  *   using NoiseModelFactor::unwhitenedError; */
   Vector unwhitenedError(const Values& x, std::vector<Matrix>& H) const {
     return unwhitenedError(x, &H);
   }
@@ -652,7 +652,7 @@ protected:
     static_assert((are_all_mat || are_all_ptrs),
                   "Arguments that are passed to the evaluateError function can only be of following the types: Matrix, "
                   "or Matrix*");
-    // if they pass all matrices then we want to pass their pointers instead
+    // If they pass all matrices then we want to pass their pointers instead
     if constexpr (are_all_mat) {
       return evaluateError(x..., (&H)...);
     } else {

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -47,7 +47,7 @@ using OptionalMatrixTypeT = Matrix*;
 using OptionalMatrixType = Matrix*;
 // These typedefs and aliases will help with making the unwhitenedError interface
 // independent of boost
-using OptionalMatrixVec = std::vector<Matrix>*;
+using OptionalMatrixVecType = std::vector<Matrix>*;
 #else
 // creating a none value to use when declaring our interfaces
 using OptionalNoneType = boost::none_t;
@@ -55,7 +55,7 @@ using OptionalNoneType = boost::none_t;
 template <typename T = void>
 using OptionalMatrixTypeT = boost::optional<Matrix&>;
 using OptionalMatrixType = boost::optional<Matrix&>;
-using OptionalMatrixVec = boost::optional<std::vector<Matrix>&>;
+using OptionalMatrixVecType = boost::optional<std::vector<Matrix>&>;
 #endif
 /**
  * Nonlinear factor base class
@@ -252,7 +252,7 @@ public:
    * If the optional arguments is specified, it should compute
    * both the function evaluation and its derivative(s) in H.
    */
-  virtual Vector unwhitenedError(const Values& x, OptionalMatrixVec H = OptionalNone) const = 0;
+  virtual Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalNone) const = 0;
 #ifdef NO_BOOST_C17
   // support taking in the actual vector instead of the pointer as well
   Vector unwhitenedError(const Values& x, std::vector<Matrix>& H) {
@@ -565,7 +565,7 @@ protected:
    */
   Vector unwhitenedError(
       const Values& x,
-      OptionalMatrixVec H = OptionalNone) const override {
+      OptionalMatrixVecType H = OptionalNone) const override {
     return unwhitenedError(boost::mp11::index_sequence_for<ValueTypes...>{}, x,
                            H);
   }
@@ -659,7 +659,7 @@ protected:
   inline Vector unwhitenedError(
       boost::mp11::index_sequence<Indices...>,  //
       const Values& x,
-      OptionalMatrixVec H = OptionalNone) const {
+      OptionalMatrixVecType H = OptionalNone) const {
     if (this->active(x)) {
       if (H) {
         return evaluateError(x.at<ValueTypes>(keys_[Indices])...,

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -433,6 +433,8 @@ class NoiseModelFactorN
   /// N is the number of variables (N-way factor)
   enum { N = sizeof...(ValueTypes) };
 
+  using NoiseModelFactor::unwhitenedError;
+
 protected:
   using Base = NoiseModelFactor;
   using This = NoiseModelFactorN<ValueTypes...>;

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -618,14 +618,16 @@ protected:
    */
   template <typename... OptionalJacArgs, typename = IndexIsValid<sizeof...(OptionalJacArgs) + 1>>
   inline Vector evaluateError(const ValueTypes&... x, OptionalJacArgs&&... H) const {
-	constexpr bool are_all_opt_mat = (... && std::is_same<OptionalMatrix, std::decay_t<OptionalJacArgs>>::value);
-	constexpr bool are_all_mat = (... && std::is_same<Matrix, std::decay_t<OptionalJacArgs>>::value);
-	static_assert((are_all_mat == false && are_all_opt_mat == false), "ERRORRR");
-    if constexpr ((... && std::is_same<OptionalMatrix, std::decay_t<OptionalJacArgs>>::value)) {
-      return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., OptionalNone);
-    } else if constexpr ((... && std::is_same<Matrix, std::decay_t<OptionalJacArgs>>::value)) {
-      return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., OptionalNone);
-    }
+	/* constexpr bool are_all_opt_mat = (... && std::is_same<OptionalMatrix, std::decay_t<OptionalJacArgs>>::value); */
+        constexpr bool are_all_mat =
+            (... && (std::is_same<Matrix, std::decay_t<OptionalJacArgs>>::value ||
+                     std::is_same<boost::none_t, std::decay_t<OptionalJacArgs>>::value));
+        static_assert(are_all_mat, "ERRORRR");
+        /* if constexpr ((... && std::is_same<OptionalMatrix, std::decay_t<OptionalJacArgs>>::value)) { */
+        /* return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., boost::none); */
+        /* } else if constexpr ((... && std::is_same<Matrix, std::decay_t<OptionalJacArgs>>::value)) { */
+        return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., boost::none);
+        /* } */
   }
 
   /// @}

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -36,13 +36,13 @@ namespace gtsam {
 /* ************************************************************************* */
 
 /** These typedefs and aliases will help with making the evaluateError interface
-* independent of boost
-* TODO(kartikarcot): Change this to OptionalMatrixNone
-* This typedef is used to indicate that the Jacobian is not required
-* and the default value used for optional matrix pointer arguments in evaluateError.
-* Had to use the static_cast of a nullptr, because the compiler is not able to
-* deduce the type of the nullptr when expanding the evaluateError templates.
-*/
+ * independent of boost
+ * TODO(kartikarcot): Change this to OptionalMatrixNone
+ * This typedef is used to indicate that the Jacobian is not required
+ * and the default value used for optional matrix pointer arguments in evaluateError.
+ * Had to use the static_cast of a nullptr, because the compiler is not able to
+ * deduce the type of the nullptr when expanding the evaluateError templates.
+ */
 #define OptionalNone static_cast<Matrix*>(nullptr)
 
 /** This typedef will be used everywhere boost::optional<Matrix&> reference was used
@@ -53,7 +53,8 @@ using OptionalMatrixType = Matrix*;
 
 /** The OptionalMatrixVecType is a pointer to a vector of matrices. It will
  * be used in situations where a vector of matrices is optional, like in 
- * unwhitenedError. */
+ * unwhitenedError.
+ */
 using OptionalMatrixVecType = std::vector<Matrix>*;
 
 /**
@@ -254,10 +255,11 @@ public:
   virtual Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = nullptr) const = 0;
 
   /** support taking in the actual vector instead of the pointer as well
-  * to get access to this version of the function from derived classes
-  * one will need to use the "using" keyword and specify that like this:
-  * public:
-  *   using NoiseModelFactor::unwhitenedError; */
+   * to get access to this version of the function from derived classes
+   * one will need to use the "using" keyword and specify that like this:
+   * public:
+   *   using NoiseModelFactor::unwhitenedError;
+   */
   Vector unwhitenedError(const Values& x, std::vector<Matrix>& H) const {
     return unwhitenedError(x, &H);
   }
@@ -613,12 +615,13 @@ protected:
   virtual Vector evaluateError(const ValueTypes&... x,
                                OptionalMatrixTypeT<ValueTypes>... H) const = 0;
 
-  // If someone uses the evaluateError function by supplying all the optional
-  // arguments then redirect the call to the one which takes pointers
-  // to get access to this version of the function from derived classes
-  // one will need to use the "using" keyword and specify that like this:
-  // public:
-  //   using NoiseModelFactorN<list the value types here>::evaluateError;
+  /** If all the optional arguments are matrices then redirect the call to 
+   * the one which takes pointers.
+   * To get access to this version of the function from derived classes
+   * one will need to use the "using" keyword and specify that like this:
+   * public:
+   *   using NoiseModelFactorN<list the value types here>::evaluateError;
+   */
 
   Vector evaluateError(const ValueTypes&... x, MatrixTypeT<ValueTypes>&... H) const {
     return evaluateError(x..., (&H)...);

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -40,7 +40,7 @@ namespace gtsam {
 #ifdef NO_BOOST_CPP17
 // These typedefs and aliases will help with making the evaluateError interface
 // independent of boost
-#define OptionalNone nullptr
+using OptionalNone = nullptr;
 template <typename T = void>
 using OptionalMatrixT = Matrix*;
 using OptionalMatrix = Matrix*;
@@ -49,6 +49,7 @@ using OptionalMatrix = Matrix*;
 using OptionalMatrixVec = std::vector<Matrix>*;
 #else
 // creating a none value to use when declaring our interfaces
+using OptionalNoneType = boost::none_t;
 #define OptionalNone boost::none
 template <typename T = void>
 using OptionalMatrixT = boost::optional<Matrix&>;
@@ -618,16 +619,11 @@ protected:
    */
   template <typename... OptionalJacArgs, typename = IndexIsValid<sizeof...(OptionalJacArgs) + 1>>
   inline Vector evaluateError(const ValueTypes&... x, OptionalJacArgs&&... H) const {
-	/* constexpr bool are_all_opt_mat = (... && std::is_same<OptionalMatrix, std::decay_t<OptionalJacArgs>>::value); */
-        constexpr bool are_all_mat =
-            (... && (std::is_same<Matrix, std::decay_t<OptionalJacArgs>>::value ||
-                     std::is_same<boost::none_t, std::decay_t<OptionalJacArgs>>::value));
-        static_assert(are_all_mat, "ERRORRR");
-        /* if constexpr ((... && std::is_same<OptionalMatrix, std::decay_t<OptionalJacArgs>>::value)) { */
-        /* return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., boost::none); */
-        /* } else if constexpr ((... && std::is_same<Matrix, std::decay_t<OptionalJacArgs>>::value)) { */
-        return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., boost::none);
-        /* } */
+    constexpr bool are_all_mat = (... && (std::is_same<Matrix, std::decay_t<OptionalJacArgs>>::value ||
+                                          std::is_same<OptionalMatrix, std::decay_t<OptionalJacArgs>>::value ||
+                                          std::is_same<OptionalNoneType, std::decay_t<OptionalJacArgs>>::value));
+    static_assert(are_all_mat, "ERRORRR");
+    return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., boost::none);
   }
 
   /// @}

--- a/gtsam/nonlinear/NonlinearFactor.h
+++ b/gtsam/nonlinear/NonlinearFactor.h
@@ -41,13 +41,17 @@ namespace gtsam {
 // These typedefs and aliases will help with making the evaluateError interface
 // independent of boost
 using OptionalNoneType = std::nullptr_t;
-#define OptionalNone = nullptr
+// TODO: Change this to OptionalMatrixNone
+#define OptionalNone static_cast<Matrix*>(nullptr)
 template <typename T = void>
 using OptionalMatrixTypeT = Matrix*;
+template <typename T = void>
+using MatrixTypeT = Matrix;
 using OptionalMatrixType = Matrix*;
 // These typedefs and aliases will help with making the unwhitenedError interface
 // independent of boost
 using OptionalMatrixVecType = std::vector<Matrix>*;
+#define OptionalMatrixVecNone static_cast<std::vector<Matrix>*>(nullptr)
 #else
 // creating a none value to use when declaring our interfaces
 using OptionalNoneType = boost::none_t;
@@ -56,6 +60,7 @@ template <typename T = void>
 using OptionalMatrixTypeT = boost::optional<Matrix&>;
 using OptionalMatrixType = boost::optional<Matrix&>;
 using OptionalMatrixVecType = boost::optional<std::vector<Matrix>&>;
+#define OptionalMatrixVecNone boost::none
 #endif
 /**
  * Nonlinear factor base class
@@ -252,10 +257,10 @@ public:
    * If the optional arguments is specified, it should compute
    * both the function evaluation and its derivative(s) in H.
    */
-  virtual Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalNone) const = 0;
-#ifdef NO_BOOST_C17
+  virtual Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const = 0;
+#ifdef NO_BOOST_CPP17
   // support taking in the actual vector instead of the pointer as well
-  Vector unwhitenedError(const Values& x, std::vector<Matrix>& H) {
+  Vector unwhitenedError(const Values& x, std::vector<Matrix>& H) const {
 	  return unwhitenedError(x, &H);
   }
 #endif
@@ -565,7 +570,7 @@ protected:
    */
   Vector unwhitenedError(
       const Values& x,
-      OptionalMatrixVecType H = OptionalNone) const override {
+      OptionalMatrixVecType H = OptionalMatrixVecNone) const override {
     return unwhitenedError(boost::mp11::index_sequence_for<ValueTypes...>{}, x,
                            H);
   }
@@ -599,8 +604,15 @@ protected:
   virtual Vector evaluateError(const ValueTypes&... x,
                                OptionalMatrixTypeT<ValueTypes>... H) const = 0;
 
-  /// @}
+#ifdef NO_BOOST_CPP17
+  // if someone uses the evaluateError function by supplying all the optional
+  // arguments then redirect the call to the one which takes pointers
+  Vector evaluateError(const ValueTypes&... x, MatrixTypeT<ValueTypes>&... H) const {
+	  return evaluateError(x..., (&H)...);
+  }
+#endif
 
+  /// @}
   /// @name Convenience method overloads
   /// @{
 
@@ -630,7 +642,7 @@ protected:
                   "or Matrix*");
 	// if they pass all matrices then we want to pass their pointers instead
 	if constexpr (are_all_mat) {
-		return evaluateError(x..., (&OptionalJacArgs)...);
+		return evaluateError(x..., (&H)...);
 	} else {
     return evaluateError(x..., std::forward<OptionalJacArgs>(H)..., static_cast<OptionalMatrixType>(OptionalNone));
 	}
@@ -659,7 +671,7 @@ protected:
   inline Vector unwhitenedError(
       boost::mp11::index_sequence<Indices...>,  //
       const Values& x,
-      OptionalMatrixVecType H = OptionalNone) const {
+      OptionalMatrixVecType H = OptionalMatrixVecNone) const {
     if (this->active(x)) {
       if (H) {
         return evaluateError(x.at<ValueTypes>(keys_[Indices])...,

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -31,6 +31,7 @@ namespace gtsam {
 
   public:
     typedef VALUE T;
+
     // Provide access to the Matrix& version of evaluateError:
     using NoiseModelFactor1<VALUE>::evaluateError;
 

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -91,7 +91,7 @@ namespace gtsam {
     /** implement functions needed to derive from Factor */
 
     /** vector of errors */
-    Vector evaluateError(const T& x, boost::optional<Matrix&> H = boost::none) const override {
+    Vector evaluateError(const T& x, OptionalMatrixType H = OptionalNone) const override {
       if (H) (*H) = Matrix::Identity(traits<T>::GetDimension(x),traits<T>::GetDimension(x));
       // manifold equivalent of z-x -> Local(x,z)
       return -traits<T>::Local(x, prior_);

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -31,7 +31,8 @@ namespace gtsam {
 
   public:
     typedef VALUE T;
-	using NoiseModelFactor1<VALUE>::evaluateError;
+    // Provide access to the Matrix& version of evaluateError:
+	  using NoiseModelFactor1<VALUE>::evaluateError;
 
   private:
 

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -32,7 +32,8 @@ namespace gtsam {
   public:
     typedef VALUE T;
     // Provide access to the Matrix& version of evaluateError:
-	  using NoiseModelFactor1<VALUE>::evaluateError;
+    using NoiseModelFactor1<VALUE>::evaluateError;
+
 
   private:
 
@@ -113,10 +114,10 @@ namespace gtsam {
       ar & BOOST_SERIALIZATION_NVP(prior_);
     }
 
-	// Alignment, see https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
-	enum { NeedsToAlign = (sizeof(T) % 16) == 0 };
+  // Alignment, see https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
+  enum { NeedsToAlign = (sizeof(T) % 16) == 0 };
   public:
-	GTSAM_MAKE_ALIGNED_OPERATOR_NEW_IF(NeedsToAlign)
+  GTSAM_MAKE_ALIGNED_OPERATOR_NEW_IF(NeedsToAlign)
   };
 
   /// traits

--- a/gtsam/nonlinear/PriorFactor.h
+++ b/gtsam/nonlinear/PriorFactor.h
@@ -31,6 +31,7 @@ namespace gtsam {
 
   public:
     typedef VALUE T;
+	using NoiseModelFactor1<VALUE>::evaluateError;
 
   private:
 
@@ -91,7 +92,7 @@ namespace gtsam {
     /** implement functions needed to derive from Factor */
 
     /** vector of errors */
-    Vector evaluateError(const T& x, OptionalMatrixType H = OptionalNone) const override {
+    Vector evaluateError(const T& x, OptionalMatrixType H) const override {
       if (H) (*H) = Matrix::Identity(traits<T>::GetDimension(x),traits<T>::GetDimension(x));
       // manifold equivalent of z-x -> Local(x,z)
       return -traits<T>::Local(x, prior_);

--- a/gtsam/nonlinear/Values-inl.h
+++ b/gtsam/nonlinear/Values-inl.h
@@ -362,7 +362,7 @@ namespace gtsam {
 
   /* ************************************************************************* */
   template<typename ValueType>
-  boost::optional<const ValueType&> Values::exists(Key j) const {
+  const ValueType * Values::exists(Key j) const {
     // Find the item
     KeyValueMap::const_iterator item = values_.find(j);
 
@@ -370,14 +370,14 @@ namespace gtsam {
       // dynamic cast the type and throw exception if incorrect
       auto ptr = dynamic_cast<const GenericValue<ValueType>*>(item->second);
       if (ptr) {
-        return ptr->value();
+        return &ptr->value();
       } else {
         // NOTE(abe): clang warns about potential side effects if done in typeid
         const Value* value = item->second;
         throw ValuesIncorrectType(j, typeid(*value), typeid(ValueType));
       }
      } else {
-      return boost::none;
+      return nullptr;
     }
   }
 

--- a/gtsam/nonlinear/Values.h
+++ b/gtsam/nonlinear/Values.h
@@ -198,12 +198,12 @@ namespace gtsam {
      * exists. */
     bool exists(Key j) const;
 
-    /** Check if a value with key \c j exists, returns the value with type
-     * \c Value if the key does exist, or boost::none if it does not exist.
+    /** Check if a value with key \c j exists, returns a pointer to the const version of the value
+     * \c Value if the key does exist, or nullptr if it does not exist.
      * Throws DynamicValuesIncorrectType if the value type associated with the
      * requested key does not match the stored value type. */
     template<typename ValueType>
-    boost::optional<const ValueType&> exists(Key j) const;
+    const ValueType * exists(Key j) const;
 
     /** Find an element by key, returning an iterator, or end() if the key was
      * not found. */

--- a/gtsam/nonlinear/tests/CMakeLists.txt
+++ b/gtsam/nonlinear/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-gtsamAddTestsGlob(nonlinear "test*.cpp" "" "gtsam")
+gtsamAddTestsGlob(nonlinear "test*.cpp" "${tests_exclude}" "gtsam")

--- a/gtsam/nonlinear/tests/CMakeLists.txt
+++ b/gtsam/nonlinear/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-gtsamAddTestsGlob(nonlinear "test*.cpp" "${tests_exclude}" "gtsam")
+gtsamAddTestsGlob(nonlinear "test*.cpp" "" "gtsam")

--- a/gtsam/nonlinear/tests/testFunctorizedFactor.cpp
+++ b/gtsam/nonlinear/tests/testFunctorizedFactor.cpp
@@ -160,7 +160,7 @@ TEST(FunctorizedFactor, Functional) {
   Matrix X = Matrix::Identity(3, 3);
   Matrix measurement = multiplier * Matrix::Identity(3, 3);
 
-  std::function<Matrix(Matrix, boost::optional<Matrix &>)> functional =
+  std::function<Matrix(Matrix, OptionalMatrixType)> functional =
       MultiplyFunctor(multiplier);
   auto factor =
       MakeFunctorizedFactor<Matrix>(key, measurement, model, functional);
@@ -233,8 +233,7 @@ TEST(FunctorizedFactor, Functional2) {
   Vector3 x(1, 2, 3);
   Vector measurement = A * x;
 
-  std::function<Matrix(Matrix, Matrix, boost::optional<Matrix &>,
-                       boost::optional<Matrix &>)>
+  std::function<Matrix(Matrix, Matrix, OptionalMatrixType, OptionalMatrixType)>
       functional = ProjectionFunctor();
   auto factor = MakeFunctorizedFactor2<Matrix, Vector>(keyA, keyx, measurement,
                                                        model2, functional);

--- a/gtsam/nonlinear/tests/testValues.cpp
+++ b/gtsam/nonlinear/tests/testValues.cpp
@@ -308,7 +308,7 @@ TEST(Values, exists_)
   config0.insert(key1, 1.0);
   config0.insert(key2, 2.0);
 
-  boost::optional<const double&> v = config0.exists<double>(key1);
+  const double* v = config0.exists<double>(key1);
   DOUBLES_EQUAL(1.0,*v,1e-9);
 }
 

--- a/gtsam/sam/BearingFactor.h
+++ b/gtsam/sam/BearingFactor.h
@@ -34,10 +34,9 @@ struct Bearing;
  */
 template <typename A1, typename A2,
           typename T = typename Bearing<A1, A2>::result_type>
-struct BearingFactor : public ExpressionFactorN<T, A1, A2>, public EvaluateErrorInterface<A1, A2>{
+struct BearingFactor : public ExpressionFactorN<T, A1, A2> {
   typedef ExpressionFactorN<T, A1, A2> Base;
 
-  using EvaluateErrorInterface<A1,A2>::evaluateError;
   /// default constructor
   BearingFactor() {}
 
@@ -62,9 +61,8 @@ struct BearingFactor : public ExpressionFactorN<T, A1, A2>, public EvaluateError
     Base::print(s, kf);
   }
   
-  virtual Vector evaluateError(const A1& a1, const A2& a2,
-    OptionalMatrixType H1, OptionalMatrixType H2) const override
-  {
+  Vector evaluateError(const A1& a1, const A2& a2,
+    OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();
     const Vector error = this->unwhitenedError(

--- a/gtsam/sam/BearingFactor.h
+++ b/gtsam/sam/BearingFactor.h
@@ -62,8 +62,8 @@ struct BearingFactor : public ExpressionFactorN<T, A1, A2> {
   }
   
   Vector evaluateError(const A1& a1, const A2& a2,
-    boost::optional<Matrix&> H1 = boost::none,
-    boost::optional<Matrix&> H2 = boost::none) const
+    OptionalMatrixType H1 = OptionalNone,
+    OptionalMatrixType H2 = OptionalNone) const
   {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();

--- a/gtsam/sam/BearingFactor.h
+++ b/gtsam/sam/BearingFactor.h
@@ -34,9 +34,10 @@ struct Bearing;
  */
 template <typename A1, typename A2,
           typename T = typename Bearing<A1, A2>::result_type>
-struct BearingFactor : public ExpressionFactorN<T, A1, A2> {
+struct BearingFactor : public ExpressionFactorN<T, A1, A2>, public EvaluateErrorInterface<A1, A2>{
   typedef ExpressionFactorN<T, A1, A2> Base;
 
+  using EvaluateErrorInterface<A1,A2>::evaluateError;
   /// default constructor
   BearingFactor() {}
 
@@ -61,13 +62,12 @@ struct BearingFactor : public ExpressionFactorN<T, A1, A2> {
     Base::print(s, kf);
   }
   
-  Vector evaluateError(const A1& a1, const A2& a2,
-    OptionalMatrixType H1 = OptionalNone,
-    OptionalMatrixType H2 = OptionalNone) const
+  virtual Vector evaluateError(const A1& a1, const A2& a2,
+    OptionalMatrixType H1, OptionalMatrixType H2) const override
   {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();
-    const Vector error = unwhitenedError(
+    const Vector error = this->unwhitenedError(
       {{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, 
       Hs);
     if (H1) *H1 = Hs[0];

--- a/gtsam/sam/BearingFactor.h
+++ b/gtsam/sam/BearingFactor.h
@@ -65,7 +65,7 @@ struct BearingFactor : public ExpressionFactorN<T, A1, A2> {
     OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();
-    const Vector error = this->unwhitenedError(
+    const Vector error = unwhitenedError(
       {{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, 
       Hs);
     if (H1) *H1 = Hs[0];

--- a/gtsam/sam/BearingRangeFactor.h
+++ b/gtsam/sam/BearingRangeFactor.h
@@ -33,7 +33,7 @@ template <typename A1, typename A2,
           typename B = typename Bearing<A1, A2>::result_type,
           typename R = typename Range<A1, A2>::result_type>
 class BearingRangeFactor
-    : public ExpressionFactorN<BearingRange<A1, A2>, A1, A2>, public EvaluateErrorInterface<A1, A2>{
+    : public ExpressionFactorN<BearingRange<A1, A2>, A1, A2> {
  private:
   typedef BearingRange<A1, A2> T;
   typedef ExpressionFactorN<T, A1, A2> Base;
@@ -41,7 +41,6 @@ class BearingRangeFactor
 
  public:
   typedef boost::shared_ptr<This> shared_ptr;
-  using EvaluateErrorInterface<A1, A2>::evaluateError;
 
   /// Default constructor
   BearingRangeFactor() {}
@@ -74,9 +73,8 @@ class BearingRangeFactor
                          Expression<A2>(keys[1]));
   }
 
-  virtual Vector evaluateError(const A1& a1, const A2& a2,
-      OptionalMatrixType H1, OptionalMatrixType H2) const override
-  {
+  Vector evaluateError(const A1& a1, const A2& a2,
+      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();
     const Vector error = this->unwhitenedError(

--- a/gtsam/sam/BearingRangeFactor.h
+++ b/gtsam/sam/BearingRangeFactor.h
@@ -33,7 +33,7 @@ template <typename A1, typename A2,
           typename B = typename Bearing<A1, A2>::result_type,
           typename R = typename Range<A1, A2>::result_type>
 class BearingRangeFactor
-    : public ExpressionFactorN<BearingRange<A1, A2>, A1, A2> {
+    : public ExpressionFactorN<BearingRange<A1, A2>, A1, A2>, public EvaluateErrorInterface<A1, A2>{
  private:
   typedef BearingRange<A1, A2> T;
   typedef ExpressionFactorN<T, A1, A2> Base;
@@ -41,6 +41,7 @@ class BearingRangeFactor
 
  public:
   typedef boost::shared_ptr<This> shared_ptr;
+  using EvaluateErrorInterface<A1, A2>::evaluateError;
 
   /// Default constructor
   BearingRangeFactor() {}
@@ -73,9 +74,8 @@ class BearingRangeFactor
                          Expression<A2>(keys[1]));
   }
 
-  Vector evaluateError(const A1& a1, const A2& a2,
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const
+  virtual Vector evaluateError(const A1& a1, const A2& a2,
+      OptionalMatrixType H1, OptionalMatrixType H2) const override
   {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();

--- a/gtsam/sam/BearingRangeFactor.h
+++ b/gtsam/sam/BearingRangeFactor.h
@@ -74,8 +74,8 @@ class BearingRangeFactor
   }
 
   Vector evaluateError(const A1& a1, const A2& a2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const
   {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -59,8 +59,9 @@ class RangeFactor : public ExpressionFactorN<T, A1, A2> {
     return Expression<T>(Range<A1, A2>(), a1_, a2_);
   }
 
-  Vector evaluateError(const A1& a1, const A2& a2, OptionalMatrixType H1 = OptionalNone,
-                               OptionalMatrixType H2 = OptionalNone) const {
+  Vector evaluateError(const A1& a1, const A2& a2, 
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const {
     std::vector<Matrix> Hs(2);
     const auto& keys = Factor::keys();
     const Vector error = Base::unwhitenedError(

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -32,12 +32,13 @@ struct Range;
  * @ingroup sam
  */
 template <typename A1, typename A2 = A1, typename T = double>
-class RangeFactor : public ExpressionFactorN<T, A1, A2> {
+class RangeFactor : public ExpressionFactorN<T, A1, A2> , public EvaluateErrorInterface<A1, A2>{
  private:
   typedef RangeFactor<A1, A2> This;
   typedef ExpressionFactorN<T, A1, A2> Base;
 
  public:
+  using EvaluateErrorInterface<A1,A2>::evaluateError;
   /// default constructor
   RangeFactor() {}
 
@@ -58,16 +59,12 @@ class RangeFactor : public ExpressionFactorN<T, A1, A2> {
     Expression<A2> a2_(keys[1]);
     return Expression<T>(Range<A1, A2>(), a1_, a2_);
   }
-  
-  Vector evaluateError(const A1& a1, const A2& a2,
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const
-  {
+
+  virtual Vector evaluateError(const A1& a1, const A2& a2, OptionalMatrixType H1,
+                               OptionalMatrixType H2) const override {
     std::vector<Matrix> Hs(2);
-    const auto &keys = Factor::keys();
-    const Vector error = Base::unwhitenedError(
-      {{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, 
-      Hs);
+    const auto& keys = Factor::keys();
+    const Vector error = Base::unwhitenedError({{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, Hs);
     if (H1) *H1 = Hs[0];
     if (H2) *H2 = Hs[1];
     return error;
@@ -100,7 +97,7 @@ struct traits<RangeFactor<A1, A2, T> >
  */
 template <typename A1, typename A2 = A1,
           typename T = typename Range<A1, A2>::result_type>
-class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
+class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> , public EvaluateErrorInterface<A1, A2>{
  private:
   typedef RangeFactorWithTransform<A1, A2> This;
   typedef ExpressionFactorN<T, A1, A2> Base;
@@ -108,6 +105,7 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
   A1 body_T_sensor_;  ///< The pose of the sensor in the body frame
 
  public:
+  using EvaluateErrorInterface<A1, A2>::evaluateError;
   //// Default constructor
   RangeFactorWithTransform() {}
 
@@ -136,9 +134,8 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
     return Expression<T>(Range<A1, A2>(), nav_T_sensor_, a2_);
   }
 
-  Vector evaluateError(const A1& a1, const A2& a2,
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const
+  virtual Vector evaluateError(const A1& a1, const A2& a2,
+      OptionalMatrixType H1, OptionalMatrixType H2) const override
   {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -63,7 +63,9 @@ class RangeFactor : public ExpressionFactorN<T, A1, A2> {
                                OptionalMatrixType H2 = OptionalNone) const {
     std::vector<Matrix> Hs(2);
     const auto& keys = Factor::keys();
-    const Vector error = Base::unwhitenedError({{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, Hs);
+    const Vector error = Base::unwhitenedError(
+        {{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}},
+        Hs);
     if (H1) *H1 = Hs[0];
     if (H2) *H2 = Hs[1];
     return error;

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -60,8 +60,8 @@ class RangeFactor : public ExpressionFactorN<T, A1, A2> {
   }
   
   Vector evaluateError(const A1& a1, const A2& a2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const
   {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();
@@ -137,8 +137,8 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
   }
 
   Vector evaluateError(const A1& a1, const A2& a2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const
   {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();

--- a/gtsam/sam/RangeFactor.h
+++ b/gtsam/sam/RangeFactor.h
@@ -32,13 +32,12 @@ struct Range;
  * @ingroup sam
  */
 template <typename A1, typename A2 = A1, typename T = double>
-class RangeFactor : public ExpressionFactorN<T, A1, A2> , public EvaluateErrorInterface<A1, A2>{
+class RangeFactor : public ExpressionFactorN<T, A1, A2> {
  private:
   typedef RangeFactor<A1, A2> This;
   typedef ExpressionFactorN<T, A1, A2> Base;
 
  public:
-  using EvaluateErrorInterface<A1,A2>::evaluateError;
   /// default constructor
   RangeFactor() {}
 
@@ -60,8 +59,8 @@ class RangeFactor : public ExpressionFactorN<T, A1, A2> , public EvaluateErrorIn
     return Expression<T>(Range<A1, A2>(), a1_, a2_);
   }
 
-  virtual Vector evaluateError(const A1& a1, const A2& a2, OptionalMatrixType H1,
-                               OptionalMatrixType H2) const override {
+  Vector evaluateError(const A1& a1, const A2& a2, OptionalMatrixType H1 = OptionalNone,
+                               OptionalMatrixType H2 = OptionalNone) const {
     std::vector<Matrix> Hs(2);
     const auto& keys = Factor::keys();
     const Vector error = Base::unwhitenedError({{keys[0], genericValue(a1)}, {keys[1], genericValue(a2)}}, Hs);
@@ -97,7 +96,7 @@ struct traits<RangeFactor<A1, A2, T> >
  */
 template <typename A1, typename A2 = A1,
           typename T = typename Range<A1, A2>::result_type>
-class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> , public EvaluateErrorInterface<A1, A2>{
+class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> {
  private:
   typedef RangeFactorWithTransform<A1, A2> This;
   typedef ExpressionFactorN<T, A1, A2> Base;
@@ -105,7 +104,6 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> , public Ev
   A1 body_T_sensor_;  ///< The pose of the sensor in the body frame
 
  public:
-  using EvaluateErrorInterface<A1, A2>::evaluateError;
   //// Default constructor
   RangeFactorWithTransform() {}
 
@@ -134,9 +132,8 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> , public Ev
     return Expression<T>(Range<A1, A2>(), nav_T_sensor_, a2_);
   }
 
-  virtual Vector evaluateError(const A1& a1, const A2& a2,
-      OptionalMatrixType H1, OptionalMatrixType H2) const override
-  {
+  Vector evaluateError(const A1& a1, const A2& a2,
+      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const {
     std::vector<Matrix> Hs(2);
     const auto &keys = Factor::keys();
     const Vector error = Base::unwhitenedError(
@@ -145,6 +142,12 @@ class RangeFactorWithTransform : public ExpressionFactorN<T, A1, A2> , public Ev
     if (H1) *H1 = Hs[0];
     if (H2) *H2 = Hs[1];
     return error;
+  }
+
+  // An evaluateError overload to accept matrices (Matrix&) and pass it to the
+  // OptionalMatrixType evaluateError overload
+  Vector evaluateError(const A1& a1, const A2& a2, Matrix& H1, Matrix& H2) const {
+	return evaluateError(a1, a2, &H1, &H2);
   }
 
   /** print contents */

--- a/gtsam/sam/tests/testRangeFactor.cpp
+++ b/gtsam/sam/tests/testRangeFactor.cpp
@@ -214,7 +214,7 @@ TEST( RangeFactor, Jacobian2D ) {
 
   // Use the factor to calculate the Jacobians
   Matrix H1Actual, H2Actual;
-  factor.evaluateError(pose, point, H1Actual, H2Actual);
+  factor.evaluateError(pose, point, &H1Actual, &H2Actual);
 
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected;

--- a/gtsam/sfm/ShonanFactor.cpp
+++ b/gtsam/sfm/ShonanFactor.cpp
@@ -75,8 +75,8 @@ bool ShonanFactor<d>::equals(const NonlinearFactor &expected,
 //******************************************************************************
 template <size_t d>
 void ShonanFactor<d>::fillJacobians(const Matrix &M1, const Matrix &M2,
-                                    boost::optional<Matrix &> H1,
-                                    boost::optional<Matrix &> H2) const {
+                                    OptionalMatrixType H1,
+                                    OptionalMatrixType H2) const {
   gttic(ShonanFactor_Jacobians);
   const size_t dim = p_ * d; // Stiefel manifold dimension
 
@@ -106,8 +106,8 @@ void ShonanFactor<d>::fillJacobians(const Matrix &M1, const Matrix &M2,
 //******************************************************************************
 template <size_t d>
 Vector ShonanFactor<d>::evaluateError(const SOn &Q1, const SOn &Q2,
-                                      boost::optional<Matrix &> H1,
-                                      boost::optional<Matrix &> H2) const {
+                                      OptionalMatrixType H1,
+                                      OptionalMatrixType H2) const {
   gttic(ShonanFactor_evaluateError);
 
   const Matrix &M1 = Q1.matrix();

--- a/gtsam/sfm/ShonanFactor.h
+++ b/gtsam/sfm/ShonanFactor.h
@@ -42,7 +42,9 @@ class GTSAM_EXPORT ShonanFactor : public NoiseModelFactorN<SOn, SOn> {
   using Rot = typename std::conditional<d == 2, Rot2, Rot3>::type;
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<SOn, SOn>::evaluateError;
+
   /// @name Constructor
   /// @{
 

--- a/gtsam/sfm/ShonanFactor.h
+++ b/gtsam/sfm/ShonanFactor.h
@@ -42,6 +42,7 @@ class GTSAM_EXPORT ShonanFactor : public NoiseModelFactorN<SOn, SOn> {
   using Rot = typename std::conditional<d == 2, Rot2, Rot3>::type;
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<SOn, SOn>::evaluateError;
 

--- a/gtsam/sfm/ShonanFactor.h
+++ b/gtsam/sfm/ShonanFactor.h
@@ -73,15 +73,15 @@ public:
   /// projects down from SO(p) to the Stiefel manifold of px3 matrices.
   Vector
   evaluateError(const SOn &Q1, const SOn &Q2,
-                boost::optional<Matrix &> H1 = boost::none,
-                boost::optional<Matrix &> H2 = boost::none) const override;
+                OptionalMatrixType H1 = OptionalNone,
+                OptionalMatrixType H2 = OptionalNone) const override;
   /// @}
 
 private:
   /// Calculate Jacobians if asked, Only implemented for d=2 and 3 in .cpp
   void fillJacobians(const Matrix &M1, const Matrix &M2,
-                     boost::optional<Matrix &> H1,
-                     boost::optional<Matrix &> H2) const;
+                     OptionalMatrixType H1,
+                     OptionalMatrixType H2) const;
 };
 
 // Explicit instantiation for d=2 and d=3 in .cpp file:

--- a/gtsam/sfm/ShonanFactor.h
+++ b/gtsam/sfm/ShonanFactor.h
@@ -42,6 +42,7 @@ class GTSAM_EXPORT ShonanFactor : public NoiseModelFactorN<SOn, SOn> {
   using Rot = typename std::conditional<d == 2, Rot2, Rot3>::type;
 
 public:
+  using NoiseModelFactor2<SOn, SOn>::evaluateError;
   /// @name Constructor
   /// @{
 
@@ -71,10 +72,7 @@ public:
 
   /// Error is Frobenius norm between Q1*P*R12 and Q2*P, where P=[I_3x3;0]
   /// projects down from SO(p) to the Stiefel manifold of px3 matrices.
-  Vector
-  evaluateError(const SOn &Q1, const SOn &Q2,
-                OptionalMatrixType H1 = OptionalNone,
-                OptionalMatrixType H2 = OptionalNone) const override;
+  Vector evaluateError(const SOn& Q1, const SOn& Q2, OptionalMatrixType H1, OptionalMatrixType H2) const override;
   /// @}
 
 private:

--- a/gtsam/sfm/TranslationFactor.h
+++ b/gtsam/sfm/TranslationFactor.h
@@ -45,6 +45,7 @@ class TranslationFactor : public NoiseModelFactorN<Point3, Point3> {
   Point3 measured_w_aZb_;
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Point3, Point3>::evaluateError;
 

--- a/gtsam/sfm/TranslationFactor.h
+++ b/gtsam/sfm/TranslationFactor.h
@@ -45,7 +45,9 @@ class TranslationFactor : public NoiseModelFactorN<Point3, Point3> {
   Point3 measured_w_aZb_;
 
  public:
+  // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Point3, Point3>::evaluateError;
+
   /// default constructor
   TranslationFactor() {}
 

--- a/gtsam/sfm/TranslationFactor.h
+++ b/gtsam/sfm/TranslationFactor.h
@@ -65,8 +65,8 @@ class TranslationFactor : public NoiseModelFactorN<Point3, Point3> {
    */
   Vector evaluateError(
       const Point3& Ta, const Point3& Tb,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const override {
     const Point3 dir = Tb - Ta;
     Matrix33 H_predicted_dir;
     const Point3 predicted = normalize(dir, H1 || H2 ? &H_predicted_dir : nullptr);

--- a/gtsam/sfm/TranslationFactor.h
+++ b/gtsam/sfm/TranslationFactor.h
@@ -45,6 +45,7 @@ class TranslationFactor : public NoiseModelFactorN<Point3, Point3> {
   Point3 measured_w_aZb_;
 
  public:
+  using NoiseModelFactor2<Point3, Point3>::evaluateError;
   /// default constructor
   TranslationFactor() {}
 
@@ -65,8 +66,8 @@ class TranslationFactor : public NoiseModelFactorN<Point3, Point3> {
    */
   Vector evaluateError(
       const Point3& Ta, const Point3& Tb,
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const override {
+      OptionalMatrixType H1,
+      OptionalMatrixType H2) const override {
     const Point3 dir = Tb - Ta;
     Matrix33 H_predicted_dir;
     const Point3 predicted = normalize(dir, H1 || H2 ? &H_predicted_dir : nullptr);

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -55,6 +55,7 @@ namespace gtsam {
     VALUE measured_; /** The measurement */
 
   public:
+
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -105,13 +105,13 @@ namespace gtsam {
     /// @{
 
     /// evaluate error, returns vector of errors size of tangent space
-    Vector evaluateError(const T& p1, const T& p2, boost::optional<Matrix&> H1 =
-      boost::none, boost::optional<Matrix&> H2 = boost::none) const override {
+    Vector evaluateError(const T& p1, const T& p2, OptionalMatrixType H1 =
+      OptionalNone, OptionalMatrixType H2 = OptionalNone) const override {
       T hx = traits<T>::Between(p1, p2, H1, H2); // h(x)
       // manifold equivalent of h(x)-z -> log(z,h(x))
 #ifdef GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR
       typename traits<T>::ChartJacobian::Jacobian Hlocal;
-      Vector rval = traits<T>::Local(measured_, hx, boost::none, (H1 || H2) ? &Hlocal : 0);
+      Vector rval = traits<T>::Local(measured_, hx, OptionalNone, (H1 || H2) ? &Hlocal : 0);
       if (H1) *H1 = Hlocal * (*H1);
       if (H2) *H2 = Hlocal * (*H2);
       return rval;

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -55,6 +55,7 @@ namespace gtsam {
     VALUE measured_; /** The measurement */
 
   public:
+	using Base::evaluateError;
 
     // shorthand for a smart pointer to a factor
     typedef typename boost::shared_ptr<BetweenFactor> shared_ptr;
@@ -105,8 +106,8 @@ namespace gtsam {
     /// @{
 
     /// evaluate error, returns vector of errors size of tangent space
-    Vector evaluateError(const T& p1, const T& p2, OptionalMatrixType H1 =
-      OptionalNone, OptionalMatrixType H2 = OptionalNone) const override {
+    Vector evaluateError(const T& p1, const T& p2,
+			OptionalMatrixType H1, OptionalMatrixType H2) const override {
       T hx = traits<T>::Between(p1, p2, H1, H2); // h(x)
       // manifold equivalent of h(x)-z -> log(z,h(x))
 #ifdef GTSAM_SLOW_BUT_CORRECT_BETWEENFACTOR

--- a/gtsam/slam/BetweenFactor.h
+++ b/gtsam/slam/BetweenFactor.h
@@ -55,7 +55,8 @@ namespace gtsam {
     VALUE measured_; /** The measurement */
 
   public:
-	using Base::evaluateError;
+    // Provide access to the Matrix& version of evaluateError:
+    using Base::evaluateError;
 
     // shorthand for a smart pointer to a factor
     typedef typename boost::shared_ptr<BetweenFactor> shared_ptr;

--- a/gtsam/slam/BoundingConstraint.h
+++ b/gtsam/slam/BoundingConstraint.h
@@ -57,8 +57,8 @@ struct BoundingConstraint1: public NoiseModelFactorN<VALUE> {
    * Must have optional argument for derivative with 1xN matrix, where
    * N = X::dim()
    */
-  virtual double value(const X& x, boost::optional<Matrix&> H =
-      boost::none) const = 0;
+  virtual double value(const X& x, OptionalMatrixType H =
+      OptionalNone) const = 0;
 
   /** active when constraint *NOT* met */
   bool active(const Values& c) const override {
@@ -69,7 +69,7 @@ struct BoundingConstraint1: public NoiseModelFactorN<VALUE> {
 
   Vector evaluateError(const X& x, OptionalMatrixType H) const override {
     Matrix D;
-    double error = value(x, D) - threshold_;
+    double error = value(x, &D) - threshold_;
     if (H) {
       if (isGreaterThan_) *H = D;
       else *H = -1.0 * D;
@@ -128,8 +128,8 @@ struct BoundingConstraint2: public NoiseModelFactorN<VALUE1, VALUE2> {
    * Must have optional argument for derivatives)
    */
   virtual double value(const X1& x1, const X2& x2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const = 0;
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const = 0;
 
   /** active when constraint *NOT* met */
   bool active(const Values& c) const override {
@@ -141,7 +141,7 @@ struct BoundingConstraint2: public NoiseModelFactorN<VALUE1, VALUE2> {
   Vector evaluateError(const X1& x1, const X2& x2,
       OptionalMatrixType H1, OptionalMatrixType H2) const override {
     Matrix D1, D2;
-    double error = value(x1, x2, D1, D2) - threshold_;
+    double error = value(x1, x2, &D1, &D2) - threshold_;
     if (H1) {
       if (isGreaterThan_)  *H1 = D1;
       else *H1 = -1.0 * D1;

--- a/gtsam/slam/BoundingConstraint.h
+++ b/gtsam/slam/BoundingConstraint.h
@@ -35,6 +35,7 @@ struct BoundingConstraint1: public NoiseModelFactorN<VALUE> {
   typedef NoiseModelFactorN<VALUE> Base;
   typedef boost::shared_ptr<BoundingConstraint1<VALUE> > shared_ptr;
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   double threshold_;
@@ -106,6 +107,7 @@ struct BoundingConstraint2: public NoiseModelFactorN<VALUE1, VALUE2> {
   typedef NoiseModelFactorN<VALUE1, VALUE2> Base;
   typedef boost::shared_ptr<BoundingConstraint2<VALUE1, VALUE2> > shared_ptr;
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   double threshold_;

--- a/gtsam/slam/BoundingConstraint.h
+++ b/gtsam/slam/BoundingConstraint.h
@@ -64,8 +64,8 @@ struct BoundingConstraint1: public NoiseModelFactorN<VALUE> {
     return (isGreaterThan_) ? x <= threshold_ : x >= threshold_;
   }
 
-  Vector evaluateError(const X& x, boost::optional<Matrix&> H =
-      boost::none) const override {
+  Vector evaluateError(const X& x, OptionalMatrixType H =
+      OptionalNone) const override {
     Matrix D;
     double error = value(x, D) - threshold_;
     if (H) {
@@ -134,8 +134,8 @@ struct BoundingConstraint2: public NoiseModelFactorN<VALUE1, VALUE2> {
   }
 
   Vector evaluateError(const X1& x1, const X2& x2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const override {
     Matrix D1, D2;
     double error = value(x1, x2, D1, D2) - threshold_;
     if (H1) {

--- a/gtsam/slam/BoundingConstraint.h
+++ b/gtsam/slam/BoundingConstraint.h
@@ -35,6 +35,8 @@ struct BoundingConstraint1: public NoiseModelFactorN<VALUE> {
   typedef NoiseModelFactorN<VALUE> Base;
   typedef boost::shared_ptr<BoundingConstraint1<VALUE> > shared_ptr;
 
+  using Base::evaluateError;
+
   double threshold_;
   bool isGreaterThan_; /// flag for greater/less than
 
@@ -64,8 +66,7 @@ struct BoundingConstraint1: public NoiseModelFactorN<VALUE> {
     return (isGreaterThan_) ? x <= threshold_ : x >= threshold_;
   }
 
-  Vector evaluateError(const X& x, OptionalMatrixType H =
-      OptionalNone) const override {
+  Vector evaluateError(const X& x, OptionalMatrixType H) const override {
     Matrix D;
     double error = value(x, D) - threshold_;
     if (H) {
@@ -105,6 +106,8 @@ struct BoundingConstraint2: public NoiseModelFactorN<VALUE1, VALUE2> {
   typedef NoiseModelFactorN<VALUE1, VALUE2> Base;
   typedef boost::shared_ptr<BoundingConstraint2<VALUE1, VALUE2> > shared_ptr;
 
+  using Base::evaluateError;
+
   double threshold_;
   bool isGreaterThan_; /// flag for greater/less than
 
@@ -134,8 +137,7 @@ struct BoundingConstraint2: public NoiseModelFactorN<VALUE1, VALUE2> {
   }
 
   Vector evaluateError(const X1& x1, const X2& x2,
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     Matrix D1, D2;
     double error = value(x1, x2, D1, D2) - threshold_;
     if (H1) {

--- a/gtsam/slam/EssentialMatrixConstraint.cpp
+++ b/gtsam/slam/EssentialMatrixConstraint.cpp
@@ -43,16 +43,20 @@ bool EssentialMatrixConstraint::equals(const NonlinearFactor& expected,
 
 /* ************************************************************************* */
 Vector EssentialMatrixConstraint::evaluateError(const Pose3& p1,
-    const Pose3& p2, boost::optional<Matrix&> Hp1,
-    boost::optional<Matrix&> Hp2) const {
+    const Pose3& p2, OptionalMatrixType Hp1,
+    OptionalMatrixType Hp2) const {
 
   // compute relative Pose3 between p1 and p2
   Pose3 _1P2_ = p1.between(p2, Hp1, Hp2);
 
   // convert to EssentialMatrix
   Matrix D_hx_1P2;
-  EssentialMatrix hx = EssentialMatrix::FromPose3(_1P2_,
-      (Hp1 || Hp2) ? boost::optional<Matrix&>(D_hx_1P2) : boost::none);
+  EssentialMatrix hx;
+  if (Hp1 || Hp2) {
+    hx = EssentialMatrix::FromPose3(_1P2_, D_hx_1P2);
+  } else {
+      hx = EssentialMatrix::FromPose3(_1P2_, OptionalNone);
+  }
 
   // Calculate derivatives if needed
   if (Hp1) {

--- a/gtsam/slam/EssentialMatrixConstraint.h
+++ b/gtsam/slam/EssentialMatrixConstraint.h
@@ -79,8 +79,8 @@ public:
 
   /** vector of errors */
   Vector evaluateError(const Pose3& p1, const Pose3& p2,
-      boost::optional<Matrix&> Hp1 = boost::none, //
-      boost::optional<Matrix&> Hp2 = boost::none) const override;
+      OptionalMatrixType Hp1 = OptionalNone, //
+      OptionalMatrixType Hp2 = OptionalNone) const override;
 
   /** return the measured */
   const EssentialMatrix& measured() const {

--- a/gtsam/slam/EssentialMatrixConstraint.h
+++ b/gtsam/slam/EssentialMatrixConstraint.h
@@ -37,6 +37,7 @@ private:
   EssentialMatrix measuredE_; /** The measurement is an essential matrix */
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor

--- a/gtsam/slam/EssentialMatrixConstraint.h
+++ b/gtsam/slam/EssentialMatrixConstraint.h
@@ -37,6 +37,7 @@ private:
   EssentialMatrix measuredE_; /** The measurement is an essential matrix */
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/slam/EssentialMatrixConstraint.h
+++ b/gtsam/slam/EssentialMatrixConstraint.h
@@ -37,6 +37,7 @@ private:
   EssentialMatrix measuredE_; /** The measurement is an essential matrix */
 
 public:
+  using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<EssentialMatrixConstraint> shared_ptr;
@@ -79,8 +80,7 @@ public:
 
   /** vector of errors */
   Vector evaluateError(const Pose3& p1, const Pose3& p2,
-      OptionalMatrixType Hp1 = OptionalNone, //
-      OptionalMatrixType Hp2 = OptionalNone) const override;
+      OptionalMatrixType Hp1, OptionalMatrixType Hp2) const override;
 
   /** return the measured */
   const EssentialMatrix& measured() const {

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -38,6 +38,8 @@ class EssentialMatrixFactor : public NoiseModelFactorN<EssentialMatrix> {
   typedef EssentialMatrixFactor This;
 
  public:
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /**
    *  Constructor
@@ -235,6 +237,7 @@ class EssentialMatrixFactor3 : public EssentialMatrixFactor2 {
   Rot3 cRb_;  ///< Rotation from body to camera frame
 
  public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /**
    *  Constructor
@@ -336,6 +339,7 @@ class EssentialMatrixFactor4
   typedef Eigen::Matrix<double, 2, DimK> JacobianCalibration;
 
  public:
+   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /**
    *  Constructor

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -91,7 +91,7 @@ class EssentialMatrixFactor : public NoiseModelFactorN<EssentialMatrix> {
   /// vector of errors returns 1D vector
   Vector evaluateError(
       const EssentialMatrix& E,
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     Vector error(1);
     error << E.error(vA_, vB_, H);
     return error;
@@ -173,8 +173,8 @@ class EssentialMatrixFactor2
    */
   Vector evaluateError(
       const EssentialMatrix& E, const double& d,
-      boost::optional<Matrix&> DE = boost::none,
-      boost::optional<Matrix&> Dd = boost::none) const override {
+      OptionalMatrixType DE = OptionalNone,
+      OptionalMatrixType Dd = OptionalNone) const override {
     // We have point x,y in image 1
     // Given a depth Z, the corresponding 3D point P1 = Z*(x,y,1) = (x,y,1)/d
     // We then convert to second camera by P2 = 1R2'*(P1-1T2)
@@ -284,13 +284,13 @@ class EssentialMatrixFactor3 : public EssentialMatrixFactor2 {
    */
   Vector evaluateError(
       const EssentialMatrix& E, const double& d,
-      boost::optional<Matrix&> DE = boost::none,
-      boost::optional<Matrix&> Dd = boost::none) const override {
+      OptionalMatrixType DE = OptionalNone,
+      OptionalMatrixType Dd = OptionalNone) const override {
     if (!DE) {
       // Convert E from body to camera frame
       EssentialMatrix cameraE = cRb_ * E;
       // Evaluate error
-      return Base::evaluateError(cameraE, d, boost::none, Dd);
+      return Base::evaluateError(cameraE, d, OptionalNone, Dd);
     } else {
       // Version with derivatives
       Matrix D_e_cameraE, D_cameraE_E;  // 2*5, 5*5
@@ -372,13 +372,13 @@ class EssentialMatrixFactor4
    */
   Vector evaluateError(
       const EssentialMatrix& E, const CALIBRATION& K,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const override {
     // converting from pixel coordinates to normalized coordinates cA and cB
     JacobianCalibration cA_H_K;  // dcA/dK
     JacobianCalibration cB_H_K;  // dcB/dK
-    Point2 cA = K.calibrate(pA_, H2 ? &cA_H_K : 0, boost::none);
-    Point2 cB = K.calibrate(pB_, H2 ? &cB_H_K : 0, boost::none);
+    Point2 cA = K.calibrate(pA_, H2 ? &cA_H_K : 0, OptionalNone);
+    Point2 cB = K.calibrate(pB_, H2 ? &cB_H_K : 0, OptionalNone);
 
     // convert to homogeneous coordinates
     Vector3 vA = EssentialMatrix::Homogeneous(cA);

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -295,7 +295,15 @@ class EssentialMatrixFactor3 : public EssentialMatrixFactor2 {
       // Version with derivatives
       Matrix D_e_cameraE, D_cameraE_E;  // 2*5, 5*5
       EssentialMatrix cameraE = E.rotate(cRb_, D_cameraE_E);
+#ifdef NO_BOOST_CPP17
+	  // Had to do this since the only overloaded function EssentialMatrixFactor2
+	  // uses the type OptionalMatrixType. Which would be a pointer when we are
+	  // not using boost. There is no way to redirect that call to the top (NoiseModelFactorN)
+	  // dereference it and bring it back to the Base (EssentialMatrixFactor2)
+      Vector e = Base::evaluateError(cameraE, d, &D_e_cameraE, Dd);
+#else
       Vector e = Base::evaluateError(cameraE, d, D_e_cameraE, Dd);
+#endif
       *DE = D_e_cameraE * D_cameraE_E;  // (2*5) * (5*5)
       return e;
     }

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -38,6 +38,7 @@ class EssentialMatrixFactor : public NoiseModelFactorN<EssentialMatrix> {
   typedef EssentialMatrixFactor This;
 
  public:
+  using Base::evaluateError;
   /**
    *  Constructor
    *  @param key Essential Matrix variable key
@@ -90,8 +91,7 @@ class EssentialMatrixFactor : public NoiseModelFactorN<EssentialMatrix> {
 
   /// vector of errors returns 1D vector
   Vector evaluateError(
-      const EssentialMatrix& E,
-      OptionalMatrixType H = OptionalNone) const override {
+      const EssentialMatrix& E, OptionalMatrixType H) const override {
     Vector error(1);
     error << E.error(vA_, vB_, H);
     return error;
@@ -115,6 +115,7 @@ class EssentialMatrixFactor2
   typedef EssentialMatrixFactor2 This;
 
  public:
+  using Base::evaluateError;
   /**
    *  Constructor
    *  @param key1 Essential Matrix variable key
@@ -173,8 +174,7 @@ class EssentialMatrixFactor2
    */
   Vector evaluateError(
       const EssentialMatrix& E, const double& d,
-      OptionalMatrixType DE = OptionalNone,
-      OptionalMatrixType Dd = OptionalNone) const override {
+      OptionalMatrixType DE, OptionalMatrixType Dd) const override {
     // We have point x,y in image 1
     // Given a depth Z, the corresponding 3D point P1 = Z*(x,y,1) = (x,y,1)/d
     // We then convert to second camera by P2 = 1R2'*(P1-1T2)
@@ -235,6 +235,7 @@ class EssentialMatrixFactor3 : public EssentialMatrixFactor2 {
   Rot3 cRb_;  ///< Rotation from body to camera frame
 
  public:
+  using Base::evaluateError;
   /**
    *  Constructor
    *  @param key1 Essential Matrix variable key
@@ -284,8 +285,7 @@ class EssentialMatrixFactor3 : public EssentialMatrixFactor2 {
    */
   Vector evaluateError(
       const EssentialMatrix& E, const double& d,
-      OptionalMatrixType DE = OptionalNone,
-      OptionalMatrixType Dd = OptionalNone) const override {
+      OptionalMatrixType DE, OptionalMatrixType Dd) const override {
     if (!DE) {
       // Convert E from body to camera frame
       EssentialMatrix cameraE = cRb_ * E;
@@ -332,6 +332,7 @@ class EssentialMatrixFactor4
   typedef Eigen::Matrix<double, 2, DimK> JacobianCalibration;
 
  public:
+  using Base::evaluateError;
   /**
    *  Constructor
    *  @param keyE Essential Matrix (from camera B to A) variable key
@@ -372,8 +373,7 @@ class EssentialMatrixFactor4
    */
   Vector evaluateError(
       const EssentialMatrix& E, const CALIBRATION& K,
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     // converting from pixel coordinates to normalized coordinates cA and cB
     JacobianCalibration cA_H_K;  // dcA/dK
     JacobianCalibration cB_H_K;  // dcB/dK

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -41,6 +41,7 @@ class EssentialMatrixFactor : public NoiseModelFactorN<EssentialMatrix> {
 
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /**
    *  Constructor
    *  @param key Essential Matrix variable key
@@ -119,6 +120,7 @@ class EssentialMatrixFactor2
  public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /**
    *  Constructor
    *  @param key1 Essential Matrix variable key
@@ -240,6 +242,7 @@ class EssentialMatrixFactor3 : public EssentialMatrixFactor2 {
  public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /**
    *  Constructor
    *  @param key1 Essential Matrix variable key
@@ -342,6 +345,7 @@ class EssentialMatrixFactor4
  public:
    // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /**
    *  Constructor
    *  @param keyE Essential Matrix (from camera B to A) variable key

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -295,15 +295,11 @@ class EssentialMatrixFactor3 : public EssentialMatrixFactor2 {
       // Version with derivatives
       Matrix D_e_cameraE, D_cameraE_E;  // 2*5, 5*5
       EssentialMatrix cameraE = E.rotate(cRb_, D_cameraE_E);
-#ifdef NO_BOOST_CPP17
 	  // Had to do this since the only overloaded function EssentialMatrixFactor2
 	  // uses the type OptionalMatrixType. Which would be a pointer when we are
 	  // not using boost. There is no way to redirect that call to the top (NoiseModelFactorN)
 	  // dereference it and bring it back to the Base (EssentialMatrixFactor2)
       Vector e = Base::evaluateError(cameraE, d, &D_e_cameraE, Dd);
-#else
-      Vector e = Base::evaluateError(cameraE, d, D_e_cameraE, Dd);
-#endif
       *DE = D_e_cameraE * D_cameraE_E;  // (2*5) * (5*5)
       return e;
     }

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -117,6 +117,7 @@ class EssentialMatrixFactor2
   typedef EssentialMatrixFactor2 This;
 
  public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /**
    *  Constructor

--- a/gtsam/slam/EssentialMatrixFactor.h
+++ b/gtsam/slam/EssentialMatrixFactor.h
@@ -118,6 +118,7 @@ class EssentialMatrixFactor2
   typedef EssentialMatrixFactor2 This;
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -240,6 +241,7 @@ class EssentialMatrixFactor3 : public EssentialMatrixFactor2 {
   Rot3 cRb_;  ///< Rotation from body to camera frame
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -343,6 +345,7 @@ class EssentialMatrixFactor4
   typedef Eigen::Matrix<double, 2, DimK> JacobianCalibration;
 
  public:
+
    // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -54,7 +54,10 @@ class FrobeniusPrior : public NoiseModelFactorN<Rot> {
   Eigen::Matrix<double, Dim, 1> vecM_;  ///< vectorized matrix to approximate
 
  public:
+
+  // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor1<Rot>::evaluateError;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Constructor
@@ -79,6 +82,8 @@ class FrobeniusFactor : public NoiseModelFactorN<Rot, Rot> {
   enum { Dim = Rot::VectorN2::RowsAtCompileTime };
 
  public:
+
+  // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Rot, Rot>::evaluateError;
   /// Constructor
   FrobeniusFactor(Key j1, Key j2, const SharedNoiseModel& model = nullptr)

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -54,6 +54,7 @@ class FrobeniusPrior : public NoiseModelFactorN<Rot> {
   Eigen::Matrix<double, Dim, 1> vecM_;  ///< vectorized matrix to approximate
 
  public:
+  using NoiseModelFactor1<Rot>::evaluateError;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Constructor
@@ -64,8 +65,7 @@ class FrobeniusPrior : public NoiseModelFactorN<Rot> {
   }
 
   /// Error is just Frobenius norm between Rot element and vectorized matrix M.
-  Vector evaluateError(const Rot& R,
-                       OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Rot& R, OptionalMatrixType H) const override {
     return R.vec(H) - vecM_;  // Jacobian is computed only when needed.
   }
 };
@@ -108,6 +108,7 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<Rot, Rot> {
   enum { Dim = Rot::VectorN2::RowsAtCompileTime };
 
  public:
+  using NoiseModelFactor2<Rot, Rot>::evaluateError;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// @name Constructor

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -65,7 +65,7 @@ class FrobeniusPrior : public NoiseModelFactorN<Rot> {
 
   /// Error is just Frobenius norm between Rot element and vectorized matrix M.
   Vector evaluateError(const Rot& R,
-                       boost::optional<Matrix&> H = boost::none) const override {
+                       OptionalMatrixType H = OptionalNone) const override {
     return R.vec(H) - vecM_;  // Jacobian is computed only when needed.
   }
 };
@@ -86,8 +86,8 @@ class FrobeniusFactor : public NoiseModelFactorN<Rot, Rot> {
 
   /// Error is just Frobenius norm between rotation matrices.
   Vector evaluateError(const Rot& R1, const Rot& R2,
-                       boost::optional<Matrix&> H1 = boost::none,
-                       boost::optional<Matrix&> H2 = boost::none) const override {
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone) const override {
     Vector error = R2.vec(H2) - R1.vec(H1);
     if (H1) *H1 = -*H1;
     return error;
@@ -150,8 +150,8 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<Rot, Rot> {
 
   /// Error is Frobenius norm between R1*R12 and R2.
   Vector evaluateError(const Rot& R1, const Rot& R2,
-                       boost::optional<Matrix&> H1 = boost::none,
-                       boost::optional<Matrix&> H2 = boost::none) const override {
+                       OptionalMatrixType H1 = OptionalNone,
+                       OptionalMatrixType H2 = OptionalNone) const override {
     const Rot R2hat = R1.compose(R12_);
     Eigen::Matrix<double, Dim, Rot::dimension> vec_H_R2hat;
     Vector error = R2.vec(H2) - R2hat.vec(H1 ? &vec_H_R2hat : nullptr);

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -85,6 +85,7 @@ class FrobeniusFactor : public NoiseModelFactorN<Rot, Rot> {
 
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Rot, Rot>::evaluateError;
+
   /// Constructor
   FrobeniusFactor(Key j1, Key j2, const SharedNoiseModel& model = nullptr)
       : NoiseModelFactorN<Rot, Rot>(ConvertNoiseModel(model, Dim), j1,
@@ -113,7 +114,9 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<Rot, Rot> {
   enum { Dim = Rot::VectorN2::RowsAtCompileTime };
 
  public:
+  // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Rot, Rot>::evaluateError;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// @name Constructor

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -79,6 +79,7 @@ class FrobeniusFactor : public NoiseModelFactorN<Rot, Rot> {
   enum { Dim = Rot::VectorN2::RowsAtCompileTime };
 
  public:
+  using NoiseModelFactor2<Rot, Rot>::evaluateError;
   /// Constructor
   FrobeniusFactor(Key j1, Key j2, const SharedNoiseModel& model = nullptr)
       : NoiseModelFactorN<Rot, Rot>(ConvertNoiseModel(model, Dim), j1,
@@ -86,8 +87,7 @@ class FrobeniusFactor : public NoiseModelFactorN<Rot, Rot> {
 
   /// Error is just Frobenius norm between rotation matrices.
   Vector evaluateError(const Rot& R1, const Rot& R2,
-                       OptionalMatrixType H1 = OptionalNone,
-                       OptionalMatrixType H2 = OptionalNone) const override {
+                       OptionalMatrixType H1, OptionalMatrixType H2) const override {
     Vector error = R2.vec(H2) - R1.vec(H1);
     if (H1) *H1 = -*H1;
     return error;
@@ -151,8 +151,7 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<Rot, Rot> {
 
   /// Error is Frobenius norm between R1*R12 and R2.
   Vector evaluateError(const Rot& R1, const Rot& R2,
-                       OptionalMatrixType H1 = OptionalNone,
-                       OptionalMatrixType H2 = OptionalNone) const override {
+                       OptionalMatrixType H1, OptionalMatrixType H2) const override {
     const Rot R2hat = R1.compose(R12_);
     Eigen::Matrix<double, Dim, Rot::dimension> vec_H_R2hat;
     Vector error = R2.vec(H2) - R2hat.vec(H1 ? &vec_H_R2hat : nullptr);

--- a/gtsam/slam/FrobeniusFactor.h
+++ b/gtsam/slam/FrobeniusFactor.h
@@ -114,6 +114,7 @@ class FrobeniusBetweenFactor : public NoiseModelFactorN<Rot, Rot> {
   enum { Dim = Rot::VectorN2::RowsAtCompileTime };
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Rot, Rot>::evaluateError;
 

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -76,6 +76,9 @@ public:
   typedef GeneralSFMFactor<CAMERA, LANDMARK> This;///< typedef for this object
   typedef NoiseModelFactorN<CAMERA, LANDMARK> Base;///< typedef for the base class
 
+  // Provide access to the Matrix& version of evaluateError:
+  using Base::evaluateError;//
+
   // shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<This> shared_ptr;
 
@@ -123,7 +126,7 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const CAMERA& camera, const LANDMARK& point,
-      OptionalMatrixType H1=OptionalNone, OptionalMatrixType H2=OptionalNone) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     try {
       return camera.project2(point,H1,H2) - measured_;
     }
@@ -258,10 +261,7 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const Pose3& pose3, const Point3& point, const CALIBRATION &calib,
-      OptionalMatrixType H1=OptionalNone,
-      OptionalMatrixType H2=OptionalNone,
-      OptionalMatrixType H3=OptionalNone) const override
-  {
+      OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3) const override {
     try {
       Camera camera(pose3,calib);
       return camera.project(point, H1, H2, H3) - measured_;

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -123,7 +123,7 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const CAMERA& camera, const LANDMARK& point,
-      boost::optional<Matrix&> H1=boost::none, boost::optional<Matrix&> H2=boost::none) const override {
+      OptionalMatrixType H1=OptionalNone, OptionalMatrixType H2=OptionalNone) const override {
     try {
       return camera.project2(point,H1,H2) - measured_;
     }
@@ -258,9 +258,9 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const Pose3& pose3, const Point3& point, const CALIBRATION &calib,
-      boost::optional<Matrix&> H1=boost::none,
-      boost::optional<Matrix&> H2=boost::none,
-      boost::optional<Matrix&> H3=boost::none) const override
+      OptionalMatrixType H1=OptionalNone,
+      OptionalMatrixType H2=OptionalNone,
+      OptionalMatrixType H3=OptionalNone) const override
   {
     try {
       Camera camera(pose3,calib);

--- a/gtsam/slam/GeneralSFMFactor.h
+++ b/gtsam/slam/GeneralSFMFactor.h
@@ -77,7 +77,7 @@ public:
   typedef NoiseModelFactorN<CAMERA, LANDMARK> Base;///< typedef for the base class
 
   // Provide access to the Matrix& version of evaluateError:
-  using Base::evaluateError;//
+  using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<This> shared_ptr;

--- a/gtsam/slam/OrientedPlane3Factor.cpp
+++ b/gtsam/slam/OrientedPlane3Factor.cpp
@@ -23,8 +23,8 @@ void OrientedPlane3Factor::print(const string& s,
 
 //***************************************************************************
 Vector OrientedPlane3Factor::evaluateError(const Pose3& pose,
-    const OrientedPlane3& plane, boost::optional<Matrix&> H1,
-    boost::optional<Matrix&> H2) const {
+    const OrientedPlane3& plane, OptionalMatrixType H1,
+    OptionalMatrixType H2) const {
   Matrix36 predicted_H_pose;
   Matrix33 predicted_H_plane, error_H_predicted;
 
@@ -64,7 +64,7 @@ bool OrientedPlane3DirectionPrior::equals(const NonlinearFactor& expected,
 
 //***************************************************************************
 Vector OrientedPlane3DirectionPrior::evaluateError(
-    const OrientedPlane3& plane, boost::optional<Matrix&> H) const {
+    const OrientedPlane3& plane, OptionalMatrixType H) const {
   Unit3 n_hat_p = measured_p_.normal();
   Unit3 n_hat_q = plane.normal();
   Matrix2 H_p;

--- a/gtsam/slam/OrientedPlane3Factor.h
+++ b/gtsam/slam/OrientedPlane3Factor.h
@@ -23,6 +23,7 @@ class GTSAM_EXPORT OrientedPlane3Factor: public NoiseModelFactorN<Pose3, Oriente
  public:
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Pose3, OrientedPlane3>::evaluateError;
+
   /// Constructor
   OrientedPlane3Factor() {
   }

--- a/gtsam/slam/OrientedPlane3Factor.h
+++ b/gtsam/slam/OrientedPlane3Factor.h
@@ -44,8 +44,8 @@ class GTSAM_EXPORT OrientedPlane3Factor: public NoiseModelFactorN<Pose3, Oriente
   /// evaluateError
   Vector evaluateError(
       const Pose3& pose, const OrientedPlane3& plane,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override;
+      OptionalMatrixType H1 = OptionalNone,
+      OptionalMatrixType H2 = OptionalNone) const override;
 };
 
 // TODO: Convert this factor to dimension two, three dimensions is redundant for direction prior
@@ -73,7 +73,7 @@ class GTSAM_EXPORT OrientedPlane3DirectionPrior : public NoiseModelFactorN<Orien
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
 
   Vector evaluateError(const OrientedPlane3& plane,
-      boost::optional<Matrix&> H = boost::none) const override;
+      OptionalMatrixType H = OptionalNone) const override;
 };
 
 } // gtsam

--- a/gtsam/slam/OrientedPlane3Factor.h
+++ b/gtsam/slam/OrientedPlane3Factor.h
@@ -21,6 +21,7 @@ class GTSAM_EXPORT OrientedPlane3Factor: public NoiseModelFactorN<Pose3, Oriente
   typedef NoiseModelFactorN<Pose3, OrientedPlane3> Base;
 
  public:
+  using NoiseModelFactor2<Pose3, OrientedPlane3>::evaluateError;
   /// Constructor
   OrientedPlane3Factor() {
   }
@@ -44,8 +45,7 @@ class GTSAM_EXPORT OrientedPlane3Factor: public NoiseModelFactorN<Pose3, Oriente
   /// evaluateError
   Vector evaluateError(
       const Pose3& pose, const OrientedPlane3& plane,
-      OptionalMatrixType H1 = OptionalNone,
-      OptionalMatrixType H2 = OptionalNone) const override;
+      OptionalMatrixType H1, OptionalMatrixType H2) const override;
 };
 
 // TODO: Convert this factor to dimension two, three dimensions is redundant for direction prior
@@ -55,6 +55,7 @@ class GTSAM_EXPORT OrientedPlane3DirectionPrior : public NoiseModelFactorN<Orien
   typedef NoiseModelFactorN<OrientedPlane3> Base;
 
  public:
+  using Base::evaluateError;
   typedef OrientedPlane3DirectionPrior This;
   /// Constructor
   OrientedPlane3DirectionPrior() {
@@ -72,8 +73,7 @@ class GTSAM_EXPORT OrientedPlane3DirectionPrior : public NoiseModelFactorN<Orien
   /// equals
   bool equals(const NonlinearFactor& expected, double tol = 1e-9) const override;
 
-  Vector evaluateError(const OrientedPlane3& plane,
-      OptionalMatrixType H = OptionalNone) const override;
+  Vector evaluateError(const OrientedPlane3& plane, OptionalMatrixType H) const override;
 };
 
 } // gtsam

--- a/gtsam/slam/OrientedPlane3Factor.h
+++ b/gtsam/slam/OrientedPlane3Factor.h
@@ -21,6 +21,7 @@ class GTSAM_EXPORT OrientedPlane3Factor: public NoiseModelFactorN<Pose3, Oriente
   typedef NoiseModelFactorN<Pose3, OrientedPlane3> Base;
 
  public:
+  // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Pose3, OrientedPlane3>::evaluateError;
   /// Constructor
   OrientedPlane3Factor() {
@@ -55,7 +56,10 @@ class GTSAM_EXPORT OrientedPlane3DirectionPrior : public NoiseModelFactorN<Orien
   typedef NoiseModelFactorN<OrientedPlane3> Base;
 
  public:
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   typedef OrientedPlane3DirectionPrior This;
   /// Constructor
   OrientedPlane3DirectionPrior() {

--- a/gtsam/slam/OrientedPlane3Factor.h
+++ b/gtsam/slam/OrientedPlane3Factor.h
@@ -21,6 +21,7 @@ class GTSAM_EXPORT OrientedPlane3Factor: public NoiseModelFactorN<Pose3, Oriente
   typedef NoiseModelFactorN<Pose3, OrientedPlane3> Base;
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor2<Pose3, OrientedPlane3>::evaluateError;
 

--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -25,6 +25,8 @@ public:
   typedef typename POSE::Translation Translation;
   typedef typename POSE::Rotation Rotation;
 
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   GTSAM_CONCEPT_POSE_TYPE(Pose)

--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -75,7 +75,7 @@ public:
   }
 
   /** h(x)-z */
-  Vector evaluateError(const Pose& pose, boost::optional<Matrix&> H = boost::none) const override {
+  Vector evaluateError(const Pose& pose, OptionalMatrixType H = OptionalNone) const override {
     const Rotation& newR = pose.rotation();
     if (H) {
       *H = Matrix::Zero(rDim, xDim);

--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -25,7 +25,6 @@ public:
   typedef typename POSE::Translation Translation;
   typedef typename POSE::Rotation Rotation;
 
-
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/slam/PoseRotationPrior.h
+++ b/gtsam/slam/PoseRotationPrior.h
@@ -25,6 +25,8 @@ public:
   typedef typename POSE::Translation Translation;
   typedef typename POSE::Rotation Rotation;
 
+  using Base::evaluateError;
+
   GTSAM_CONCEPT_POSE_TYPE(Pose)
   GTSAM_CONCEPT_GROUP_TYPE(Pose)
   GTSAM_CONCEPT_LIE_TYPE(Rotation)
@@ -75,7 +77,7 @@ public:
   }
 
   /** h(x)-z */
-  Vector evaluateError(const Pose& pose, OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Pose& pose, OptionalMatrixType H) const override {
     const Rotation& newR = pose.rotation();
     if (H) {
       *H = Matrix::Zero(rDim, xDim);

--- a/gtsam/slam/PoseTranslationPrior.h
+++ b/gtsam/slam/PoseTranslationPrior.h
@@ -25,6 +25,8 @@ public:
   typedef POSE Pose;
   typedef typename POSE::Translation Translation;
   typedef typename POSE::Rotation Rotation;
+  
+  using Base::evaluateError;
 
   GTSAM_CONCEPT_POSE_TYPE(Pose)
   GTSAM_CONCEPT_GROUP_TYPE(Pose)
@@ -59,7 +61,7 @@ public:
         gtsam::NonlinearFactor::shared_ptr(new This(*this))); }
 
   /** h(x)-z */
-  Vector evaluateError(const Pose& pose, OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Pose& pose, OptionalMatrixType H) const override {
     const Translation& newTrans = pose.translation();
     const Rotation& R = pose.rotation();
     const int tDim = traits<Translation>::GetDimension(newTrans);

--- a/gtsam/slam/PoseTranslationPrior.h
+++ b/gtsam/slam/PoseTranslationPrior.h
@@ -26,6 +26,8 @@ public:
   typedef typename POSE::Translation Translation;
   typedef typename POSE::Rotation Rotation;
   
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   GTSAM_CONCEPT_POSE_TYPE(Pose)

--- a/gtsam/slam/PoseTranslationPrior.h
+++ b/gtsam/slam/PoseTranslationPrior.h
@@ -26,7 +26,6 @@ public:
   typedef typename POSE::Translation Translation;
   typedef typename POSE::Rotation Rotation;
   
-
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/slam/PoseTranslationPrior.h
+++ b/gtsam/slam/PoseTranslationPrior.h
@@ -59,7 +59,7 @@ public:
         gtsam::NonlinearFactor::shared_ptr(new This(*this))); }
 
   /** h(x)-z */
-  Vector evaluateError(const Pose& pose, boost::optional<Matrix&> H = boost::none) const override {
+  Vector evaluateError(const Pose& pose, OptionalMatrixType H = OptionalNone) const override {
     const Translation& newTrans = pose.translation();
     const Rotation& R = pose.rotation();
     const int tDim = traits<Translation>::GetDimension(newTrans);

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -60,6 +60,8 @@ namespace gtsam {
     /// shorthand for a smart pointer to a factor
     typedef boost::shared_ptr<This> shared_ptr;
 
+	using Base::evaluateError;
+
     /// Default constructor
     GenericProjectionFactor() :
         measured_(0, 0), throwCheirality_(false), verboseCheirality_(false) {
@@ -133,7 +135,7 @@ namespace gtsam {
 
     /// Evaluate error h(x)-z and optionally derivatives
     Vector evaluateError(const Pose3& pose, const Point3& point,
-        OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2) const override {
       try {
         if(body_P_sensor_) {
           if(H1) {

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -133,7 +133,7 @@ namespace gtsam {
 
     /// Evaluate error h(x)-z and optionally derivatives
     Vector evaluateError(const Pose3& pose, const Point3& point,
-        boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 = boost::none) const override {
+        OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const override {
       try {
         if(body_P_sensor_) {
           if(H1) {

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -53,6 +53,8 @@ namespace gtsam {
 
     /// shorthand for base class type
     typedef NoiseModelFactor2<POSE, LANDMARK> Base;
+
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
     /// shorthand for this class

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -52,15 +52,14 @@ namespace gtsam {
   public:
 
     /// shorthand for base class type
-    typedef NoiseModelFactorN<POSE, LANDMARK> Base;
+    typedef NoiseModelFactor2<POSE, LANDMARK> Base;
+    using Base::evaluateError;
 
     /// shorthand for this class
     typedef GenericProjectionFactor<POSE, LANDMARK, CALIBRATION> This;
 
     /// shorthand for a smart pointer to a factor
     typedef boost::shared_ptr<This> shared_ptr;
-
-	using Base::evaluateError;
 
     /// Default constructor
     GenericProjectionFactor() :

--- a/gtsam/slam/ProjectionFactor.h
+++ b/gtsam/slam/ProjectionFactor.h
@@ -52,7 +52,7 @@ namespace gtsam {
   public:
 
     /// shorthand for base class type
-    typedef NoiseModelFactor2<POSE, LANDMARK> Base;
+    typedef NoiseModelFactorN<POSE, LANDMARK> Base;
 
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;

--- a/gtsam/slam/ReferenceFrameFactor.h
+++ b/gtsam/slam/ReferenceFrameFactor.h
@@ -62,6 +62,7 @@ protected:
 public:
   typedef NoiseModelFactorN<POINT, TRANSFORM, POINT> Base;
   typedef ReferenceFrameFactor<POINT, TRANSFORM> This;
+  using Base::evaluateError;
 
   typedef POINT Point;
   typedef TRANSFORM Transform;
@@ -95,9 +96,8 @@ public:
 
   /** Combined cost and derivative function using boost::optional */
   Vector evaluateError(const Point& global, const Transform& trans, const Point& local,
-        OptionalMatrixType Dforeign = OptionalNone,
-        OptionalMatrixType Dtrans = OptionalNone,
-        OptionalMatrixType Dlocal = OptionalNone) const override {
+        OptionalMatrixType Dforeign, OptionalMatrixType Dtrans,
+        OptionalMatrixType Dlocal) const override {
     Point newlocal = transform_point<Transform,Point>(trans, global, Dtrans, Dforeign);
     if (Dlocal) {
       *Dlocal = -1* Matrix::Identity(traits<Point>::dimension, traits<Point>::dimension);

--- a/gtsam/slam/ReferenceFrameFactor.h
+++ b/gtsam/slam/ReferenceFrameFactor.h
@@ -62,6 +62,8 @@ protected:
 public:
   typedef NoiseModelFactorN<POINT, TRANSFORM, POINT> Base;
   typedef ReferenceFrameFactor<POINT, TRANSFORM> This;
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   typedef POINT Point;

--- a/gtsam/slam/ReferenceFrameFactor.h
+++ b/gtsam/slam/ReferenceFrameFactor.h
@@ -95,12 +95,13 @@ public:
 
   /** Combined cost and derivative function using boost::optional */
   Vector evaluateError(const Point& global, const Transform& trans, const Point& local,
-        boost::optional<Matrix&> Dforeign = boost::none,
-        boost::optional<Matrix&> Dtrans = boost::none,
-        boost::optional<Matrix&> Dlocal = boost::none) const override {
+        OptionalMatrixType Dforeign = OptionalNone,
+        OptionalMatrixType Dtrans = OptionalNone,
+        OptionalMatrixType Dlocal = OptionalNone) const override {
     Point newlocal = transform_point<Transform,Point>(trans, global, Dtrans, Dforeign);
-    if (Dlocal)
+    if (Dlocal) {
       *Dlocal = -1* Matrix::Identity(traits<Point>::dimension, traits<Point>::dimension);
+    }
     return traits<Point>::Local(local,newlocal);
   }
 

--- a/gtsam/slam/ReferenceFrameFactor.h
+++ b/gtsam/slam/ReferenceFrameFactor.h
@@ -29,8 +29,8 @@ namespace gtsam {
 template<class T, class P>
 P transform_point(
     const T& trans, const P& global,
-    boost::optional<Matrix&> Dtrans,
-    boost::optional<Matrix&> Dglobal) {
+    OptionalMatrixType Dtrans,
+    OptionalMatrixType Dglobal) {
   return trans.transformFrom(global, Dtrans, Dglobal);
 }
 

--- a/gtsam/slam/RotateFactor.h
+++ b/gtsam/slam/RotateFactor.h
@@ -74,6 +74,7 @@ class RotateDirectionsFactor: public NoiseModelFactorN<Rot3> {
   typedef RotateDirectionsFactor This;
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// Constructor

--- a/gtsam/slam/RotateFactor.h
+++ b/gtsam/slam/RotateFactor.h
@@ -28,6 +28,7 @@ class RotateFactor: public NoiseModelFactorN<Rot3> {
   typedef RotateFactor This;
 
 public:
+  using Base::evaluateError;
 
   /// Constructor
   RotateFactor(Key key, const Rot3& P, const Rot3& Z,
@@ -50,8 +51,7 @@ public:
   }
 
   /// vector of errors returns 2D vector
-  Vector evaluateError(const Rot3& R,
-      OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Rot3& R, OptionalMatrixType H) const override {
     // predict p_ as q = R*z_, derivative H will be filled if not none
     Point3 q = R.rotate(z_,H);
     // error is just difference, and note derivative of that wrpt q is I3
@@ -72,6 +72,7 @@ class RotateDirectionsFactor: public NoiseModelFactorN<Rot3> {
   typedef RotateDirectionsFactor This;
 
 public:
+  using Base::evaluateError;
 
   /// Constructor
   RotateDirectionsFactor(Key key, const Unit3& i_p, const Unit3& c_z,
@@ -102,7 +103,7 @@ public:
   }
 
   /// vector of errors returns 2D vector
-  Vector evaluateError(const Rot3& iRc, OptionalMatrixType H = OptionalNone) const override {
+  Vector evaluateError(const Rot3& iRc, OptionalMatrixType H) const override {
     Unit3 i_q = iRc * c_z_;
     Vector error = i_p_.error(i_q, H);
     if (H) {

--- a/gtsam/slam/RotateFactor.h
+++ b/gtsam/slam/RotateFactor.h
@@ -74,6 +74,7 @@ class RotateDirectionsFactor: public NoiseModelFactorN<Rot3> {
   typedef RotateDirectionsFactor This;
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam/slam/RotateFactor.h
+++ b/gtsam/slam/RotateFactor.h
@@ -28,6 +28,8 @@ class RotateFactor: public NoiseModelFactorN<Rot3> {
   typedef RotateFactor This;
 
 public:
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// Constructor

--- a/gtsam/slam/RotateFactor.h
+++ b/gtsam/slam/RotateFactor.h
@@ -51,7 +51,7 @@ public:
 
   /// vector of errors returns 2D vector
   Vector evaluateError(const Rot3& R,
-      boost::optional<Matrix&> H = boost::none) const override {
+      OptionalMatrixType H = OptionalNone) const override {
     // predict p_ as q = R*z_, derivative H will be filled if not none
     Point3 q = R.rotate(z_,H);
     // error is just difference, and note derivative of that wrpt q is I3
@@ -102,7 +102,7 @@ public:
   }
 
   /// vector of errors returns 2D vector
-  Vector evaluateError(const Rot3& iRc, boost::optional<Matrix&> H = boost::none) const override {
+  Vector evaluateError(const Rot3& iRc, OptionalMatrixType H = OptionalNone) const override {
     Unit3 i_q = iRc * c_z_;
     Vector error = i_p_.error(i_q, H);
     if (H) {

--- a/gtsam/slam/SmartProjectionFactor.h
+++ b/gtsam/slam/SmartProjectionFactor.h
@@ -337,8 +337,9 @@ protected:
    */
   bool triangulateAndComputeE(Matrix& E, const Cameras& cameras) const {
     bool nonDegenerate = triangulateForLinearize(cameras);
-    if (nonDegenerate)
-      cameras.project2(*result_, boost::none, E);
+    if (nonDegenerate) {
+      cameras.project2(*result_, nullptr, &E);
+    }
     return nonDegenerate;
   }
 

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -48,9 +48,10 @@ public:
   typedef boost::shared_ptr<GenericStereoFactor> shared_ptr;  ///< typedef for shared pointer to this object
   typedef POSE CamPose;                                       ///< typedef for Pose Lie Value type
 
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 	
-
   /**
    * Default constructor
    */

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -120,7 +120,7 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const Pose3& pose, const Point3& point,
-      boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const override {
     try {
       if(body_P_sensor_) {
         if(H1) {

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -48,6 +48,9 @@ public:
   typedef boost::shared_ptr<GenericStereoFactor> shared_ptr;  ///< typedef for shared pointer to this object
   typedef POSE CamPose;                                       ///< typedef for Pose Lie Value type
 
+  using Base::evaluateError;
+	
+
   /**
    * Default constructor
    */
@@ -120,7 +123,7 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const Pose3& pose, const Point3& point,
-      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     try {
       if(body_P_sensor_) {
         if(H1) {

--- a/gtsam/slam/StereoFactor.h
+++ b/gtsam/slam/StereoFactor.h
@@ -48,10 +48,9 @@ public:
   typedef boost::shared_ptr<GenericStereoFactor> shared_ptr;  ///< typedef for shared pointer to this object
   typedef POSE CamPose;                                       ///< typedef for Pose Lie Value type
 
-
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
-	
+
   /**
    * Default constructor
    */

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -61,6 +61,8 @@ public:
 
   /// shorthand for a smart pointer to a factor
   using shared_ptr = boost::shared_ptr<This>;
+
+  // Provide access to the Matrix& version of evaluateError:
   using NoiseModelFactor1<Point3>::evaluateError;
 
   /// Default constructor

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -119,10 +119,10 @@ public:
   }
 
   /// Evaluate error h(x)-z and optionally derivatives
-  Vector evaluateError(const Point3& point, boost::optional<Matrix&> H2 =
-      boost::none) const override {
+  Vector evaluateError(const Point3& point, OptionalMatrixType H2 =
+      OptionalNone) const override {
     try {
-      return traits<Measurement>::Local(measured_, camera_.project2(point, boost::none, H2));
+      return traits<Measurement>::Local(measured_, camera_.project2(point, OptionalNone, H2));
     } catch (CheiralityException& e) {
       if (H2)
         *H2 = Matrix::Zero(traits<Measurement>::dimension, 3);

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -61,6 +61,7 @@ public:
 
   /// shorthand for a smart pointer to a factor
   using shared_ptr = boost::shared_ptr<This>;
+  using NoiseModelFactor1<Point3>::evaluateError;
 
   /// Default constructor
   TriangulationFactor() :
@@ -119,8 +120,7 @@ public:
   }
 
   /// Evaluate error h(x)-z and optionally derivatives
-  Vector evaluateError(const Point3& point, OptionalMatrixType H2 =
-      OptionalNone) const override {
+  Vector evaluateError(const Point3& point, OptionalMatrixType H2) const override {
     try {
       return traits<Measurement>::Local(measured_, camera_.project2(point, OptionalNone, H2));
     } catch (CheiralityException& e) {

--- a/gtsam/slam/tests/testBetweenFactor.cpp
+++ b/gtsam/slam/tests/testBetweenFactor.cpp
@@ -36,16 +36,13 @@ TEST(BetweenFactor, Rot3) {
   EXPECT(assert_equal(expected,actual/*, 1e-100*/)); // Uncomment to make unit test fail
 
   Matrix numericalH1 = numericalDerivative21<Vector3, Rot3, Rot3>(
-      std::function<Vector(const Rot3&, const Rot3&)>(std::bind(
-          &BetweenFactor<Rot3>::evaluateError, factor, std::placeholders::_1,
-          std::placeholders::_2, boost::none, boost::none)),
+        [&factor](const Rot3& r1, const Rot3& r2) {return factor.evaluateError(r1, r2);},
       R1, R2, 1e-5);
   EXPECT(assert_equal(numericalH1,actualH1, 1E-5));
 
   Matrix numericalH2 = numericalDerivative22<Vector3,Rot3,Rot3>(
-      std::function<Vector(const Rot3&, const Rot3&)>(std::bind(
-          &BetweenFactor<Rot3>::evaluateError, factor, std::placeholders::_1, std::placeholders::_2, boost::none,
-          boost::none)), R1, R2, 1e-5);
+        [&factor](const Rot3& r1, const Rot3& r2) {return factor.evaluateError(r1, r2);},
+        R1, R2, 1e-5);
   EXPECT(assert_equal(numericalH2,actualH2, 1E-5));
 }
 

--- a/gtsam/slam/tests/testEssentialMatrixConstraint.cpp
+++ b/gtsam/slam/tests/testEssentialMatrixConstraint.cpp
@@ -53,12 +53,11 @@ TEST( EssentialMatrixConstraint, test ) {
 
   // Calculate numerical derivatives
   Matrix expectedH1 = numericalDerivative11<Vector5, Pose3>(
-      std::bind(&EssentialMatrixConstraint::evaluateError, &factor,
-                std::placeholders::_1, pose2, boost::none, boost::none),
-      pose1);
+		[&factor, &pose2](const Pose3& p1) {return factor.evaluateError(p1, pose2);},
+		pose1);
+
   Matrix expectedH2 = numericalDerivative11<Vector5, Pose3>(
-      std::bind(&EssentialMatrixConstraint::evaluateError, &factor, pose1,
-                std::placeholders::_1, boost::none, boost::none),
+		[&factor, &pose1](const Pose3& p2) {return factor.evaluateError(pose1, p2);},
       pose2);
 
   // Use the factor to calculate the derivative

--- a/gtsam/slam/tests/testOrientedPlane3Factor.cpp
+++ b/gtsam/slam/tests/testOrientedPlane3Factor.cpp
@@ -140,7 +140,7 @@ TEST( OrientedPlane3Factor, Derivatives ) {
   OrientedPlane3Factor factor(p.planeCoefficients(), noise, poseKey, planeKey);
 
   // Calculate numerical derivatives
-  std::function<Vector(const Pose3&, const OrientedPlane3&)> f = [&factor](const Pose3& p, const OrientedPlane3& o) {
+  auto f = [&factor](const Pose3& p, const OrientedPlane3& o) {
     return factor.evaluateError(p, o);
   };
   Matrix numericalH1 = numericalDerivative21<Vector, Pose3, OrientedPlane3>(f, poseLin, pLin);

--- a/gtsam/slam/tests/testOrientedPlane3Factor.cpp
+++ b/gtsam/slam/tests/testOrientedPlane3Factor.cpp
@@ -140,9 +140,9 @@ TEST( OrientedPlane3Factor, Derivatives ) {
   OrientedPlane3Factor factor(p.planeCoefficients(), noise, poseKey, planeKey);
 
   // Calculate numerical derivatives
-  std::function<Vector(const Pose3 &, const OrientedPlane3 &)> f = std::bind(
-      &OrientedPlane3Factor::evaluateError, factor, std::placeholders::_1,
-      std::placeholders::_2, boost::none, boost::none);
+  std::function<Vector(const Pose3&, const OrientedPlane3&)> f = [&factor](const Pose3& p, const OrientedPlane3& o) {
+    return factor.evaluateError(p, o);
+  };
   Matrix numericalH1 = numericalDerivative21<Vector, Pose3, OrientedPlane3>(f, poseLin, pLin);
   Matrix numericalH2 = numericalDerivative22<Vector, Pose3, OrientedPlane3>(f, poseLin, pLin);
 
@@ -180,16 +180,13 @@ TEST( OrientedPlane3DirectionPrior, Constructor ) {
 
   // Calculate numerical derivatives
   Matrix expectedH1 = numericalDerivative11<Vector, OrientedPlane3>(
-      std::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, std::placeholders::_1,
-          boost::none), T1);
+		  [&factor](const OrientedPlane3& o) {return factor.evaluateError(o);}, T1);
 
   Matrix expectedH2 = numericalDerivative11<Vector, OrientedPlane3>(
-      std::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, std::placeholders::_1,
-          boost::none), T2);
+      [&factor](const OrientedPlane3& o) {return factor.evaluateError(o);}, T2);
 
   Matrix expectedH3 = numericalDerivative11<Vector, OrientedPlane3>(
-      std::bind(&OrientedPlane3DirectionPrior::evaluateError, &factor, std::placeholders::_1,
-          boost::none), T3);
+      [&factor](const OrientedPlane3& o) { return factor.evaluateError(o); }, T3);
 
   // Use the factor to calculate the derivative
   Matrix actualH1, actualH2, actualH3;

--- a/gtsam/slam/tests/testRotateFactor.cpp
+++ b/gtsam/slam/tests/testRotateFactor.cpp
@@ -69,14 +69,14 @@ TEST (RotateFactor, test) {
   Matrix actual, expected;
   // Use numerical derivatives to calculate the expected Jacobian
   {
-    expected = numericalDerivative11<Vector3,Rot3>(
-        std::bind(&RotateFactor::evaluateError, &f, std::placeholders::_1, boost::none), iRc);
+    expected = numericalDerivative11<Vector3, Rot3>(
+			[&f](const Rot3& r) { return f.evaluateError(r); }, iRc);
     f.evaluateError(iRc, actual);
     EXPECT(assert_equal(expected, actual, 1e-9));
   }
   {
-    expected = numericalDerivative11<Vector3,Rot3>(
-        std::bind(&RotateFactor::evaluateError, &f, std::placeholders::_1, boost::none), R);
+    expected = numericalDerivative11<Vector3, Rot3>(
+			[&f](const Rot3& r) { return f.evaluateError(r); }, R);
     f.evaluateError(R, actual);
     EXPECT(assert_equal(expected, actual, 1e-9));
   }
@@ -141,15 +141,13 @@ TEST (RotateDirectionsFactor, test) {
   // Use numerical derivatives to calculate the expected Jacobian
   {
     expected = numericalDerivative11<Vector,Rot3>(
-        std::bind(&RotateDirectionsFactor::evaluateError, &f, std::placeholders::_1,
-            boost::none), iRc);
+			[&f](const Rot3& r) {return f.evaluateError(r);}, iRc);
     f.evaluateError(iRc, actual);
     EXPECT(assert_equal(expected, actual, 1e-9));
   }
   {
     expected = numericalDerivative11<Vector,Rot3>(
-        std::bind(&RotateDirectionsFactor::evaluateError, &f, std::placeholders::_1,
-            boost::none), R);
+			[&f](const Rot3& r) {return f.evaluateError(r);}, R);
     f.evaluateError(R, actual);
     EXPECT(assert_equal(expected, actual, 1e-9));
   }

--- a/gtsam/slam/tests/testTriangulationFactor.cpp
+++ b/gtsam/slam/tests/testTriangulationFactor.cpp
@@ -59,7 +59,7 @@ TEST( triangulation, TriangulationFactor ) {
   factor.evaluateError(landmark, HActual);
 
   Matrix HExpected = numericalDerivative11<Vector,Point3>(
-      std::bind(&Factor::evaluateError, &factor, std::placeholders::_1, boost::none), landmark);
+		  [&factor](const Point3& l) { return factor.evaluateError(l);}, landmark);
 
   // Verify the Jacobians are correct
   CHECK(assert_equal(HExpected, HActual, 1e-3));
@@ -82,8 +82,8 @@ TEST( triangulation, TriangulationFactorStereo ) {
   Matrix HActual;
   factor.evaluateError(landmark, HActual);
 
-  Matrix HExpected = numericalDerivative11<Vector,Point3>(
-      std::bind(&Factor::evaluateError, &factor, std::placeholders::_1, boost::none), landmark);
+  Matrix HExpected = numericalDerivative11<Vector, Point3>(
+		  [&factor](const Point3& l) { return factor.evaluateError(l);}, landmark);
 
   // Verify the Jacobians are correct
   CHECK(assert_equal(HExpected, HActual, 1e-3));

--- a/gtsam_unstable/dynamics/FullIMUFactor.h
+++ b/gtsam_unstable/dynamics/FullIMUFactor.h
@@ -34,6 +34,8 @@ protected:
   double dt_; /// time between measurements
 
 public:
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /** Standard constructor */

--- a/gtsam_unstable/dynamics/FullIMUFactor.h
+++ b/gtsam_unstable/dynamics/FullIMUFactor.h
@@ -34,6 +34,7 @@ protected:
   double dt_; /// time between measurements
 
 public:
+  using Base::evaluateError;
 
   /** Standard constructor */
   FullIMUFactor(const Vector3& accel, const Vector3& gyro,
@@ -84,8 +85,7 @@ public:
    *  z - h(x1,x2)
    */
   Vector evaluateError(const PoseRTV& x1, const PoseRTV& x2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     Vector9 z;
     z.head(3).operator=(accel_); // Strange syntax to work around ambiguous operator error with clang
     z.segment(3, 3).operator=(gyro_); // Strange syntax to work around ambiguous operator error with clang
@@ -99,8 +99,7 @@ public:
 
   /** dummy version that fails for non-dynamic poses */
   virtual Vector evaluateError(const Pose3& x1, const Pose3& x2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const {
+      OptionalMatrixType H1, OptionalMatrixType H2) const {
     assert(false);
     return Vector6::Zero();
   }

--- a/gtsam_unstable/dynamics/IMUFactor.h
+++ b/gtsam_unstable/dynamics/IMUFactor.h
@@ -32,6 +32,7 @@ protected:
   double dt_; /// time between measurements
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /** Standard constructor */

--- a/gtsam_unstable/dynamics/IMUFactor.h
+++ b/gtsam_unstable/dynamics/IMUFactor.h
@@ -32,6 +32,7 @@ protected:
   double dt_; /// time between measurements
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/dynamics/IMUFactor.h
+++ b/gtsam_unstable/dynamics/IMUFactor.h
@@ -32,6 +32,7 @@ protected:
   double dt_; /// time between measurements
 
 public:
+  using Base::evaluateError;
 
   /** Standard constructor */
   IMUFactor(const Vector3& accel, const Vector3& gyro,
@@ -77,8 +78,7 @@ public:
    *  z - h(x1,x2)
    */
   Vector evaluateError(const PoseRTV& x1, const PoseRTV& x2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     const Vector6 meas = z();
     if (H1) *H1 = numericalDerivative21<Vector6, PoseRTV, PoseRTV>(
         std::bind(This::predict_proxy, std::placeholders::_1, std::placeholders::_2, dt_, meas), x1, x2, 1e-5);
@@ -89,8 +89,7 @@ public:
 
   /** dummy version that fails for non-dynamic poses */
   virtual Vector evaluateError(const Pose3& x1, const Pose3& x2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const {
+      OptionalMatrixType H1, OptionalMatrixType H2) const {
     assert(false); // no corresponding factor here
     return Vector6::Zero();
   }

--- a/gtsam_unstable/dynamics/Pendulum.h
+++ b/gtsam_unstable/dynamics/Pendulum.h
@@ -32,6 +32,7 @@ protected:
   double h_;  // time step
 
 public:
+  using Base::evaluateError;
 
   typedef boost::shared_ptr<PendulumFactor1> shared_ptr;
 
@@ -46,9 +47,8 @@ public:
 
   /** q_k + h*v - q_k1 = 0, with optional derivatives */
   Vector evaluateError(const double& qk1, const double& qk, const double& v,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3) const override {
     const size_t p = 1;
     if (H1) *H1 = -Matrix::Identity(p,p);
     if (H2) *H2 = Matrix::Identity(p,p);
@@ -81,6 +81,8 @@ protected:
 
 public:
 
+  using Base::evaluateError;
+
   typedef boost::shared_ptr<PendulumFactor2 > shared_ptr;
 
   ///Constructor.  vk1: v_{k+1}, vk: v_k, qkey: q's key depending on the chosen method, h: time step
@@ -94,9 +96,8 @@ public:
 
   /**  v_k - h*g/L*sin(q) - v_k1 = 0, with optional derivatives */
   Vector evaluateError(const double & vk1, const double & vk, const double & q,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3) const override {
     const size_t p = 1;
     if (H1) *H1 = -Matrix::Identity(p,p);
     if (H2) *H2 = Matrix::Identity(p,p);
@@ -130,6 +131,8 @@ protected:
 
 public:
 
+  using Base::evaluateError;
+
   typedef boost::shared_ptr<PendulumFactorPk > shared_ptr;
 
   ///Constructor
@@ -145,9 +148,8 @@ public:
 
   /**  1/h mr^2 (qk1-qk)+mgrh (1-a) sin((1-a)pk + a*pk1) - pk = 0, with optional derivatives */
   Vector evaluateError(const double & pk, const double & qk, const double & qk1,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3) const override {
     const size_t p = 1;
 
     double qmid = (1-alpha_)*qk + alpha_*qk1;
@@ -185,6 +187,7 @@ protected:
   double alpha_; //! in [0,1], define the mid-point between [q_k,q_{k+1}] for approximation. The sympletic rule above can be obtained as a special case when alpha = 0.
 
 public:
+  using Base::evaluateError;
 
   typedef boost::shared_ptr<PendulumFactorPk1 > shared_ptr;
 
@@ -201,9 +204,8 @@ public:
 
   /**  1/h mr^2 (qk1-qk) - mgrh a sin((1-a)pk + a*pk1) - pk1 = 0, with optional derivatives */
   Vector evaluateError(const double & pk1, const double & qk, const double & qk1,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3) const override {
     const size_t p = 1;
 
     double qmid = (1-alpha_)*qk + alpha_*qk1;

--- a/gtsam_unstable/dynamics/Pendulum.h
+++ b/gtsam_unstable/dynamics/Pendulum.h
@@ -191,6 +191,7 @@ protected:
   double alpha_; //! in [0,1], define the mid-point between [q_k,q_{k+1}] for approximation. The sympletic rule above can be obtained as a special case when alpha = 0.
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/dynamics/Pendulum.h
+++ b/gtsam_unstable/dynamics/Pendulum.h
@@ -32,6 +32,8 @@ protected:
   double h_;  // time step
 
 public:
+
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   typedef boost::shared_ptr<PendulumFactor1> shared_ptr;
@@ -81,6 +83,7 @@ protected:
 
 public:
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   typedef boost::shared_ptr<PendulumFactor2 > shared_ptr;
@@ -131,6 +134,7 @@ protected:
 
 public:
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   typedef boost::shared_ptr<PendulumFactorPk > shared_ptr;
@@ -187,6 +191,7 @@ protected:
   double alpha_; //! in [0,1], define the mid-point between [q_k,q_{k+1}] for approximation. The sympletic rule above can be obtained as a special case when alpha = 0.
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   typedef boost::shared_ptr<PendulumFactorPk1 > shared_ptr;

--- a/gtsam_unstable/dynamics/SimpleHelicopter.h
+++ b/gtsam_unstable/dynamics/SimpleHelicopter.h
@@ -29,7 +29,9 @@ class Reconstruction : public NoiseModelFactorN<Pose3, Pose3, Vector6>  {
   double h_;  // time step
   typedef NoiseModelFactorN<Pose3, Pose3, Vector6> Base;
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   Reconstruction(Key gKey1, Key gKey, Key xiKey, double h, double mu = 1000.0) :
     Base(noiseModel::Constrained::All(6, std::abs(mu)), gKey1, gKey,
         xiKey), h_(h) {
@@ -89,6 +91,7 @@ class DiscreteEulerPoincareHelicopter : public NoiseModelFactorN<Vector6, Vector
   typedef NoiseModelFactorN<Vector6, Vector6, Pose3> Base;
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   DiscreteEulerPoincareHelicopter(Key xiKey1, Key xiKey_1, Key gKey,

--- a/gtsam_unstable/dynamics/SimpleHelicopter.h
+++ b/gtsam_unstable/dynamics/SimpleHelicopter.h
@@ -29,6 +29,7 @@ class Reconstruction : public NoiseModelFactorN<Pose3, Pose3, Vector6>  {
   double h_;  // time step
   typedef NoiseModelFactorN<Pose3, Pose3, Vector6> Base;
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -91,6 +92,7 @@ class DiscreteEulerPoincareHelicopter : public NoiseModelFactorN<Vector6, Vector
   typedef NoiseModelFactorN<Vector6, Vector6, Pose3> Base;
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/dynamics/SimpleHelicopter.h
+++ b/gtsam_unstable/dynamics/SimpleHelicopter.h
@@ -29,6 +29,7 @@ class Reconstruction : public NoiseModelFactorN<Pose3, Pose3, Vector6>  {
   double h_;  // time step
   typedef NoiseModelFactorN<Pose3, Pose3, Vector6> Base;
 public:
+  using Base::evaluateError;
   Reconstruction(Key gKey1, Key gKey, Key xiKey, double h, double mu = 1000.0) :
     Base(noiseModel::Constrained::All(6, std::abs(mu)), gKey1, gKey,
         xiKey), h_(h) {
@@ -42,9 +43,8 @@ public:
 
   /** \f$ log((g_k\exp(h\xi_k))^{-1}g_{k+1}) = 0 \f$, with optional derivatives */
   Vector evaluateError(const Pose3& gk1, const Pose3& gk, const Vector6& xik,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3) const override {
 
     Matrix6 D_exphxi_xi;
     Pose3 exphxi = Pose3::Expmap(h_ * xik, H3 ? &D_exphxi_xi : 0);
@@ -89,6 +89,8 @@ class DiscreteEulerPoincareHelicopter : public NoiseModelFactorN<Vector6, Vector
   typedef NoiseModelFactorN<Vector6, Vector6, Pose3> Base;
 
 public:
+  using Base::evaluateError;
+
   DiscreteEulerPoincareHelicopter(Key xiKey1, Key xiKey_1, Key gKey,
       double h, const Matrix& Inertia, const Vector& Fu, double m,
       double mu = 1000.0) :
@@ -108,9 +110,8 @@ public:
    *       pk_1 = CT_TLN(-h*xi_k_1)*Inertia*xi_k_1
    * */
   Vector evaluateError(const Vector6& xik, const Vector6& xik_1, const Pose3& gk,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3) const override {
 
     Vector muk = Inertia_*xik;
     Vector muk_1 = Inertia_*xik_1;
@@ -161,9 +162,8 @@ public:
   }
 
   Vector evaluateError(const Vector6& xik, const Vector6& xik_1, const Pose3& gk,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const {
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3) const {
     if (H1) {
       (*H1) = numericalDerivative31(
           std::function<Vector(const Vector6&, const Vector6&, const Pose3&)>(

--- a/gtsam_unstable/dynamics/VelocityConstraint.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint.h
@@ -34,7 +34,8 @@ typedef enum {
  */
 class VelocityConstraint : public gtsam::NoiseModelFactorN<PoseRTV,PoseRTV> {
 public:
-  typedef gtsam::NoiseModelFactorN<PoseRTV,PoseRTV> Base;
+  typedef gtsam::NoiseModelFactor2<PoseRTV,PoseRTV> Base;
+  using Base::evaluateError;
 
 protected:
 
@@ -83,8 +84,7 @@ public:
    * Calculates the error for trapezoidal model given
    */
   gtsam::Vector evaluateError(const PoseRTV& x1, const PoseRTV& x2,
-      boost::optional<gtsam::Matrix&> H1=boost::none,
-      boost::optional<gtsam::Matrix&> H2=boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     if (H1) *H1 = gtsam::numericalDerivative21<gtsam::Vector,PoseRTV,PoseRTV>(
         std::bind(VelocityConstraint::evaluateError_, std::placeholders::_1,
             std::placeholders::_2, dt_, integration_mode_), x1, x2, 1e-5);

--- a/gtsam_unstable/dynamics/VelocityConstraint.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint.h
@@ -35,6 +35,7 @@ typedef enum {
 class VelocityConstraint : public gtsam::NoiseModelFactorN<PoseRTV,PoseRTV> {
 public:
   typedef gtsam::NoiseModelFactor2<PoseRTV,PoseRTV> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
 protected:

--- a/gtsam_unstable/dynamics/VelocityConstraint.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint.h
@@ -35,6 +35,7 @@ typedef enum {
 class VelocityConstraint : public gtsam::NoiseModelFactorN<PoseRTV,PoseRTV> {
 public:
   typedef gtsam::NoiseModelFactor2<PoseRTV,PoseRTV> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/dynamics/VelocityConstraint3.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint3.h
@@ -25,6 +25,7 @@ public:
 
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   typedef boost::shared_ptr<VelocityConstraint3 > shared_ptr;
 
   ///TODO: comment

--- a/gtsam_unstable/dynamics/VelocityConstraint3.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint3.h
@@ -23,6 +23,7 @@ protected:
 
 public:
 
+  using Base::evaluateError;
   typedef boost::shared_ptr<VelocityConstraint3 > shared_ptr;
 
   ///TODO: comment
@@ -37,9 +38,8 @@ public:
 
   /** x1 + v*dt - x2 = 0, with optional derivatives */
   Vector evaluateError(const double& x1, const double& x2, const double& v,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3) const override {
     const size_t p = 1;
     if (H1) *H1 = Matrix::Identity(p,p);
     if (H2) *H2 = -Matrix::Identity(p,p);

--- a/gtsam_unstable/dynamics/VelocityConstraint3.h
+++ b/gtsam_unstable/dynamics/VelocityConstraint3.h
@@ -23,6 +23,7 @@ protected:
 
 public:
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   typedef boost::shared_ptr<VelocityConstraint3 > shared_ptr;
 

--- a/gtsam_unstable/dynamics/tests/testSimpleHelicopter.cpp
+++ b/gtsam_unstable/dynamics/tests/testSimpleHelicopter.cpp
@@ -58,10 +58,11 @@ TEST( Reconstruction, evaluateError) {
   EXPECT(
       assert_equal(Z_6x1, constraint.evaluateError(g2, g1, V1_g1, H1, H2, H3), tol));
 
-  std::function<Vector(const Pose3&, const Pose3&, const Vector6&)> f = [&constraint](const Pose3& a1, const Pose3& a2,
-                                                                                      const Vector6& a3) {
+  std::function<Vector(const Pose3&, const Pose3&, const Vector6&)> f = 
+    [&constraint](const Pose3& a1, const Pose3& a2, const Vector6& a3) {
     return constraint.evaluateError(a1, a2, a3);
   };
+
   Matrix numericalH1 = numericalDerivative31(f, g2, g1, V1_g1, 1e-5);
 
   Matrix numericalH2 = numericalDerivative32(f, g2, g1, V1_g1, 1e-5);

--- a/gtsam_unstable/geometry/InvDepthCamera3.h
+++ b/gtsam_unstable/geometry/InvDepthCamera3.h
@@ -19,6 +19,7 @@
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/PinholeCamera.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 
 namespace gtsam {
 
@@ -83,9 +84,9 @@ public:
    */
   inline gtsam::Point2 project(const Vector5& pw,
       double rho,
-      boost::optional<gtsam::Matrix&> H1 = boost::none,
-      boost::optional<gtsam::Matrix&> H2 = boost::none,
-      boost::optional<gtsam::Matrix&> H3 = boost::none) const {
+      OptionalJacobian<2,6> H1 = {},
+      OptionalJacobian<2,5> H2 = {},
+      OptionalJacobian<2,1> H3 = {}) const {
 
     gtsam::Point3 ray_base(pw.segment(0,3));
     double theta = pw(3), phi = pw(4);

--- a/gtsam_unstable/geometry/Pose3Upright.cpp
+++ b/gtsam_unstable/geometry/Pose3Upright.cpp
@@ -86,7 +86,7 @@ Pose3Upright Pose3Upright::inverse(OptionalJacobian<4, 4> H1) const {
     return Pose3Upright(T_.inverse(), -z_);
   }
   OptionalJacobian<3, 3>::Jacobian H3x3;
-  // TODO: Could not use reference to a view into H1 and reuse memory
+  // TODO(kartikarcot): Could not use reference to a view into H1 and reuse memory
   // Eigen::Ref<Eigen::Matrix<double, 3, 3>> H3x3 = H1->topLeftCorner(3,3);
   Pose3Upright result(T_.inverse(H3x3), -z_);
   Matrix H1_ = -I_4x4;
@@ -102,7 +102,7 @@ Pose3Upright Pose3Upright::compose(const Pose3Upright& p2,
   if (!H1 && !H2)
     return Pose3Upright(T_.compose(p2.T_), z_ + p2.z_);
 
-  // TODO: Could not use reference to a view into H1 and reuse memory
+  // TODO(kartikarcot): Could not use reference to a view into H1 and reuse memory
   OptionalJacobian<3, 3>::Jacobian H3x3;
   Pose3Upright result(T_.compose(p2.T_, H3x3), z_ + p2.z_);
   if (H1) {
@@ -121,7 +121,7 @@ Pose3Upright Pose3Upright::between(const Pose3Upright& p2,
   if (!H1 && !H2)
     return Pose3Upright(T_.between(p2.T_), p2.z_ - z_);
 
-  // TODO: Could not use reference to a view into H1 and H2 to reuse memory
+  // TODO(kartikarcot): Could not use reference to a view into H1 and H2 to reuse memory
   OptionalJacobian<3, 3>::Jacobian H3x3_1, H3x3_2;
   Pose3Upright result(T_.between(p2.T_, H3x3_1, H3x3_2), p2.z_ - z_);
   if (H1) {

--- a/gtsam_unstable/geometry/Pose3Upright.h
+++ b/gtsam_unstable/geometry/Pose3Upright.h
@@ -98,12 +98,12 @@ public:
   static Pose3Upright Identity() { return Pose3Upright(); }
 
   /// inverse transformation with derivatives
-  Pose3Upright inverse(boost::optional<Matrix&> H1=boost::none) const;
+  Pose3Upright inverse(OptionalJacobian<4,4> H1=boost::none) const;
 
   ///compose this transformation onto another (first *this and then p2)
   Pose3Upright compose(const Pose3Upright& p2,
-      boost::optional<Matrix&> H1=boost::none,
-      boost::optional<Matrix&> H2=boost::none) const;
+      OptionalJacobian<4,4> H1=boost::none,
+      OptionalJacobian<4,4> H2=boost::none) const;
 
   /// compose syntactic sugar
   inline Pose3Upright operator*(const Pose3Upright& T) const { return compose(T); }
@@ -113,8 +113,8 @@ public:
    * as well as optionally the derivatives
    */
   Pose3Upright between(const Pose3Upright& p2,
-      boost::optional<Matrix&> H1=boost::none,
-      boost::optional<Matrix&> H2=boost::none) const;
+      OptionalJacobian<4,4> H1=boost::none,
+      OptionalJacobian<4,4> H2=boost::none) const;
 
   /// @}
   /// @name Lie Group

--- a/gtsam_unstable/geometry/SimWall2D.cpp
+++ b/gtsam_unstable/geometry/SimWall2D.cpp
@@ -25,7 +25,7 @@ bool SimWall2D::equals(const SimWall2D& other, double tol) const {
 }
 
 /* ************************************************************************* */
-bool SimWall2D::intersects(const SimWall2D& B, boost::optional<Point2&> pt) const {
+bool SimWall2D::intersects(const SimWall2D& B, Point2* pt) const {
   const bool debug = false;
 
   const SimWall2D& A = *this;

--- a/gtsam_unstable/geometry/SimWall2D.h
+++ b/gtsam_unstable/geometry/SimWall2D.h
@@ -51,7 +51,15 @@ namespace gtsam {
      * returns true if they intersect, with the intersection
      * point in the optional second argument
      */
-    bool intersects(const SimWall2D& wall, boost::optional<Point2&> pt=boost::none) const;
+    bool intersects(const SimWall2D& wall, Point2* pt = nullptr) const;
+    
+    /**
+     * An overload of intersects that takes an l-value reference to a Point2
+     * instead of a pointer.
+     */
+    bool intersects(const SimWall2D& wall, Point2& pt) const {
+      return intersects(wall, &pt);
+    }
 
     /**
      * norm is a 2D point representing the norm of the wall

--- a/gtsam_unstable/geometry/tests/testInvDepthCamera3.cpp
+++ b/gtsam_unstable/geometry/tests/testInvDepthCamera3.cpp
@@ -94,7 +94,7 @@ TEST( InvDepthFactor, Dproject_pose)
   Matrix expected = numericalDerivative31(project_,level_pose, landmark, inv_depth);
   InvDepthCamera3<Cal3_S2> inv_camera(level_pose,K);
   Matrix actual;
-  inv_camera.project(landmark, inv_depth, actual, boost::none, boost::none);
+  inv_camera.project(landmark, inv_depth, actual, {}, {});
   EXPECT(assert_equal(expected,actual,1e-6));
 }
 
@@ -106,7 +106,7 @@ TEST( InvDepthFactor, Dproject_landmark)
   Matrix expected = numericalDerivative32(project_,level_pose, landmark, inv_depth);
   InvDepthCamera3<Cal3_S2> inv_camera(level_pose,K);
   Matrix actual;
-  inv_camera.project(landmark, inv_depth, boost::none, actual, boost::none);
+  inv_camera.project(landmark, inv_depth, {}, actual, {});
   EXPECT(assert_equal(expected,actual,1e-7));
 }
 
@@ -118,7 +118,7 @@ TEST( InvDepthFactor, Dproject_inv_depth)
   Matrix expected = numericalDerivative33(project_,level_pose, landmark, inv_depth);
   InvDepthCamera3<Cal3_S2> inv_camera(level_pose,K);
   Matrix actual;
-  inv_camera.project(landmark, inv_depth, boost::none, boost::none, actual);
+  inv_camera.project(landmark, inv_depth, {}, {}, actual);
   EXPECT(assert_equal(expected,actual,1e-7));
 }
 

--- a/gtsam_unstable/slam/BetweenFactorEM.h
+++ b/gtsam_unstable/slam/BetweenFactorEM.h
@@ -145,7 +145,7 @@ public:
 
   /* ************************************************************************* */
   Vector whitenedError(const Values& x,
-      boost::optional<std::vector<Matrix>&> H = boost::none) const {
+      OptionalMatrixVecType H = OptionalMatrixVecNone) const {
 
     bool debug = true;
 
@@ -227,6 +227,12 @@ public:
 
     return err_wh_eq;
   }
+
+#ifdef NO_BOOST_CPP17
+  Vector whitenedError(const Values& x, std::vector<Matrix>& H) const {
+	  return whitenedError(x, &H);
+  }
+#endif
 
   /* ************************************************************************* */
   Vector calcIndicatorProb(const Values& x) const {

--- a/gtsam_unstable/slam/BetweenFactorEM.h
+++ b/gtsam_unstable/slam/BetweenFactorEM.h
@@ -228,11 +228,9 @@ public:
     return err_wh_eq;
   }
 
-#ifdef NO_BOOST_CPP17
   Vector whitenedError(const Values& x, std::vector<Matrix>& H) const {
 	  return whitenedError(x, &H);
   }
-#endif
 
   /* ************************************************************************* */
   Vector calcIndicatorProb(const Values& x) const {

--- a/gtsam_unstable/slam/BetweenFactorEM.h
+++ b/gtsam_unstable/slam/BetweenFactorEM.h
@@ -228,6 +228,8 @@ public:
     return err_wh_eq;
   }
 
+  // A function overload that takes a vector of matrices and passes it to the
+  // function above which uses a pointer to a vector instead.
   Vector whitenedError(const Values& x, std::vector<Matrix>& H) const {
 	  return whitenedError(x, &H);
   }

--- a/gtsam_unstable/slam/BetweenFactorEM.h
+++ b/gtsam_unstable/slam/BetweenFactorEM.h
@@ -145,7 +145,7 @@ public:
 
   /* ************************************************************************* */
   Vector whitenedError(const Values& x,
-      OptionalMatrixVecType H = OptionalMatrixVecNone) const {
+      OptionalMatrixVecType H = nullptr) const {
 
     bool debug = true;
 

--- a/gtsam_unstable/slam/BiasedGPSFactor.h
+++ b/gtsam_unstable/slam/BiasedGPSFactor.h
@@ -37,6 +37,7 @@ namespace gtsam {
     Point3 measured_; /** The measurement */
 
   public:
+
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 

--- a/gtsam_unstable/slam/BiasedGPSFactor.h
+++ b/gtsam_unstable/slam/BiasedGPSFactor.h
@@ -37,7 +37,8 @@ namespace gtsam {
     Point3 measured_; /** The measurement */
 
   public:
-	using Base::evaluateError;
+    // Provide access to the Matrix& version of evaluateError:
+    using Base::evaluateError;
 
     // shorthand for a smart pointer to a factor
     typedef boost::shared_ptr<BiasedGPSFactor> shared_ptr;

--- a/gtsam_unstable/slam/BiasedGPSFactor.h
+++ b/gtsam_unstable/slam/BiasedGPSFactor.h
@@ -37,6 +37,7 @@ namespace gtsam {
     Point3 measured_; /** The measurement */
 
   public:
+	using Base::evaluateError;
 
     // shorthand for a smart pointer to a factor
     typedef boost::shared_ptr<BiasedGPSFactor> shared_ptr;
@@ -73,8 +74,7 @@ namespace gtsam {
 
     /** vector of errors */
     Vector evaluateError(const Pose3& pose, const Point3& bias,
-        boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 =
-            boost::none) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2) const override {
 
       if (H1 || H2){
         H1->resize(3,6); // jacobian wrt pose

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
@@ -114,7 +114,6 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<EquivInertialNavFactor_GlobalVel> shared_ptr;
 

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
@@ -111,6 +111,7 @@ private:
 
 public:
 	
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
@@ -110,6 +110,8 @@ private:
   boost::optional<POSE> body_P_sensor_;   // The pose of the sensor in the body frame
 
 public:
+	
+  using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<EquivInertialNavFactor_GlobalVel> shared_ptr;
@@ -299,11 +301,8 @@ public:
   }
 
   Vector evaluateError(const POSE& Pose1, const VELOCITY& Vel1, const IMUBIAS& Bias1, const POSE& Pose2, const VELOCITY& Vel2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none,
-      boost::optional<Matrix&> H4 = boost::none,
-      boost::optional<Matrix&> H5 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3, OptionalMatrixType H4,
+      OptionalMatrixType H5) const override {
 
     // TODO: Write analytical derivative calculations
     // Jacobian w.r.t. Pose1

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel.h
@@ -114,6 +114,7 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<EquivInertialNavFactor_GlobalVel> shared_ptr;
 

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -109,6 +109,7 @@ private:
 
 public:
 
+  using Base::evaluateError;
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<EquivInertialNavFactor_GlobalVel_NoBias> shared_ptr;
 
@@ -270,10 +271,8 @@ public:
   }
 
   Vector evaluateError(const POSE& Pose1, const VELOCITY& Vel1, const POSE& Pose2, const VELOCITY& Vel2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none,
-      boost::optional<Matrix&> H4 = boost::none) const {
+      OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3,
+      OptionalMatrixType H4) const {
 
     // TODO: Write analytical derivative calculations
     // Jacobian w.r.t. Pose1

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -112,6 +112,7 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<EquivInertialNavFactor_GlobalVel_NoBias> shared_ptr;
 

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -112,7 +112,6 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<EquivInertialNavFactor_GlobalVel_NoBias> shared_ptr;
 

--- a/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
+++ b/gtsam_unstable/slam/EquivInertialNavFactor_GlobalVel_NoBias.h
@@ -109,7 +109,9 @@ private:
 
 public:
 
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<EquivInertialNavFactor_GlobalVel_NoBias> shared_ptr;
 

--- a/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
+++ b/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
@@ -53,6 +53,7 @@ private:
   Vector tau_;
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
+++ b/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
@@ -53,6 +53,7 @@ private:
   Vector tau_;
 
 public:
+  using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<GaussMarkov1stOrderFactor> shared_ptr;
@@ -88,8 +89,7 @@ public:
 
   /** vector of errors */
   Vector evaluateError(const VALUE& p1, const VALUE& p2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
 
     Vector v1( traits<VALUE>::Logmap(p1) );
     Vector v2( traits<VALUE>::Logmap(p2) );

--- a/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
+++ b/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
@@ -56,6 +56,7 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<GaussMarkov1stOrderFactor> shared_ptr;
 

--- a/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
+++ b/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
@@ -53,6 +53,7 @@ private:
   Vector tau_;
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor

--- a/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
+++ b/gtsam_unstable/slam/GaussMarkov1stOrderFactor.h
@@ -57,7 +57,6 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<GaussMarkov1stOrderFactor> shared_ptr;
 

--- a/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
+++ b/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
@@ -99,7 +99,6 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<InertialNavFactor_GlobalVelocity> shared_ptr;
 

--- a/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
+++ b/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
@@ -95,6 +95,7 @@ private:
   boost::optional<POSE> body_P_sensor_; // The pose of the sensor in the body frame
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
+++ b/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
@@ -95,6 +95,7 @@ private:
   boost::optional<POSE> body_P_sensor_; // The pose of the sensor in the body frame
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor

--- a/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
+++ b/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
@@ -95,6 +95,7 @@ private:
   boost::optional<POSE> body_P_sensor_; // The pose of the sensor in the body frame
 
 public:
+  using Base::evaluateError;
 
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<InertialNavFactor_GlobalVelocity> shared_ptr;
@@ -226,11 +227,8 @@ public:
 
   /** implement functions needed to derive from Factor */
   Vector evaluateError(const POSE& Pose1, const VELOCITY& Vel1, const IMUBIAS& Bias1, const POSE& Pose2, const VELOCITY& Vel2,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none,
-      boost::optional<Matrix&> H4 = boost::none,
-      boost::optional<Matrix&> H5 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3, OptionalMatrixType H4,
+      OptionalMatrixType H5) const override {
 
     // TODO: Write analytical derivative calculations
     // Jacobian w.r.t. Pose1

--- a/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
+++ b/gtsam_unstable/slam/InertialNavFactor_GlobalVelocity.h
@@ -98,6 +98,7 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   // shorthand for a smart pointer to a factor
   typedef typename boost::shared_ptr<InertialNavFactor_GlobalVelocity> shared_ptr;
 

--- a/gtsam_unstable/slam/InvDepthFactor3.h
+++ b/gtsam_unstable/slam/InvDepthFactor3.h
@@ -39,7 +39,6 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   /// shorthand for this class
   typedef InvDepthFactor3<POSE, LANDMARK, INVDEPTH> This;
 

--- a/gtsam_unstable/slam/InvDepthFactor3.h
+++ b/gtsam_unstable/slam/InvDepthFactor3.h
@@ -35,6 +35,7 @@ public:
 
   /// shorthand for base class type
   typedef NoiseModelFactor3<POSE, LANDMARK, INVDEPTH> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/InvDepthFactor3.h
+++ b/gtsam_unstable/slam/InvDepthFactor3.h
@@ -35,6 +35,7 @@ public:
 
   /// shorthand for base class type
   typedef NoiseModelFactor3<POSE, LANDMARK, INVDEPTH> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// shorthand for this class

--- a/gtsam_unstable/slam/InvDepthFactor3.h
+++ b/gtsam_unstable/slam/InvDepthFactor3.h
@@ -34,7 +34,8 @@ protected:
 public:
 
   /// shorthand for base class type
-  typedef NoiseModelFactorN<POSE, LANDMARK, INVDEPTH> Base;
+  typedef NoiseModelFactor3<POSE, LANDMARK, INVDEPTH> Base;
+  using Base::evaluateError;
 
   /// shorthand for this class
   typedef InvDepthFactor3<POSE, LANDMARK, INVDEPTH> This;
@@ -83,9 +84,7 @@ public:
 
   /// Evaluate error h(x)-z and optionally derivatives
   Vector evaluateError(const POSE& pose, const Vector5& point, const INVDEPTH& invDepth,
-      boost::optional<Matrix&> H1=boost::none,
-      boost::optional<Matrix&> H2=boost::none,
-      boost::optional<Matrix&> H3=boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3) const override {
     try {
       InvDepthCamera3<Cal3_S2> camera(pose, K_);
       return camera.project(point, invDepth, H1, H2, H3) - measured_;

--- a/gtsam_unstable/slam/InvDepthFactor3.h
+++ b/gtsam_unstable/slam/InvDepthFactor3.h
@@ -38,6 +38,7 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   /// shorthand for this class
   typedef InvDepthFactor3<POSE, LANDMARK, INVDEPTH> This;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant1.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant1.h
@@ -35,6 +35,7 @@ public:
 
   /// shorthand for base class type
   typedef NoiseModelFactor2<Pose3, Vector6> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// shorthand for this class

--- a/gtsam_unstable/slam/InvDepthFactorVariant1.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant1.h
@@ -34,7 +34,8 @@ protected:
 public:
 
   /// shorthand for base class type
-  typedef NoiseModelFactorN<Pose3, Vector6> Base;
+  typedef NoiseModelFactor2<Pose3, Vector6> Base;
+  using Base::evaluateError;
 
   /// shorthand for this class
   typedef InvDepthFactorVariant1 This;
@@ -103,8 +104,7 @@ public:
 
   /// Evaluate error h(x)-z and optionally derivatives
   Vector evaluateError(const Pose3& pose, const Vector6& landmark,
-      boost::optional<Matrix&> H1=boost::none,
-      boost::optional<Matrix&> H2=boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
 
     if (H1) {
       (*H1) = numericalDerivative11<Vector, Pose3>(

--- a/gtsam_unstable/slam/InvDepthFactorVariant1.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant1.h
@@ -39,7 +39,6 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   /// shorthand for this class
   typedef InvDepthFactorVariant1 This;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant1.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant1.h
@@ -35,6 +35,7 @@ public:
 
   /// shorthand for base class type
   typedef NoiseModelFactor2<Pose3, Vector6> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant1.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant1.h
@@ -38,6 +38,7 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   /// shorthand for this class
   typedef InvDepthFactorVariant1 This;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant2.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant2.h
@@ -40,6 +40,7 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   /// shorthand for this class
   typedef InvDepthFactorVariant2 This;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant2.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant2.h
@@ -37,6 +37,7 @@ public:
 
   /// shorthand for base class type
   typedef NoiseModelFactor2<Pose3, Vector3> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant2.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant2.h
@@ -37,6 +37,7 @@ public:
 
   /// shorthand for base class type
   typedef NoiseModelFactor2<Pose3, Vector3> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// shorthand for this class

--- a/gtsam_unstable/slam/InvDepthFactorVariant2.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant2.h
@@ -36,7 +36,8 @@ protected:
 public:
 
   /// shorthand for base class type
-  typedef NoiseModelFactorN<Pose3, Vector3> Base;
+  typedef NoiseModelFactor2<Pose3, Vector3> Base;
+  using Base::evaluateError;
 
   /// shorthand for this class
   typedef InvDepthFactorVariant2 This;
@@ -106,8 +107,7 @@ public:
 
   /// Evaluate error h(x)-z and optionally derivatives
   Vector evaluateError(const Pose3& pose, const Vector3& landmark,
-      boost::optional<Matrix&> H1=boost::none,
-      boost::optional<Matrix&> H2=boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
 
     if (H1) {
       (*H1) = numericalDerivative11<Vector, Pose3>(

--- a/gtsam_unstable/slam/InvDepthFactorVariant2.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant2.h
@@ -41,7 +41,6 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   /// shorthand for this class
   typedef InvDepthFactorVariant2 This;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant3.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant3.h
@@ -35,6 +35,7 @@ public:
 
   /// shorthand for base class type
   typedef NoiseModelFactor2<Pose3, Vector3> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant3.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant3.h
@@ -39,7 +39,6 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
-
   /// shorthand for this class
   typedef InvDepthFactorVariant3a This;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant3.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant3.h
@@ -38,6 +38,7 @@ public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   /// shorthand for this class
   typedef InvDepthFactorVariant3a This;
 

--- a/gtsam_unstable/slam/InvDepthFactorVariant3.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant3.h
@@ -34,7 +34,8 @@ protected:
 public:
 
   /// shorthand for base class type
-  typedef NoiseModelFactorN<Pose3, Vector3> Base;
+  typedef NoiseModelFactor2<Pose3, Vector3> Base;
+  using Base::evaluateError;
 
   /// shorthand for this class
   typedef InvDepthFactorVariant3a This;
@@ -106,8 +107,7 @@ public:
 
   /// Evaluate error h(x)-z and optionally derivatives
   Vector evaluateError(const Pose3& pose, const Vector3& landmark,
-      boost::optional<Matrix&> H1=boost::none,
-      boost::optional<Matrix&> H2=boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
 
     if(H1) {
       (*H1) = numericalDerivative11<Vector, Pose3>(
@@ -232,9 +232,7 @@ public:
 
   /// Evaluate error h(x)-z and optionally derivatives
   Vector evaluateError(const Pose3& pose1, const Pose3& pose2, const Vector3& landmark,
-      boost::optional<Matrix&> H1=boost::none,
-      boost::optional<Matrix&> H2=boost::none,
-      boost::optional<Matrix&> H3=boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3) const override {
 
     if(H1)
       (*H1) = numericalDerivative11<Vector, Pose3>(

--- a/gtsam_unstable/slam/InvDepthFactorVariant3.h
+++ b/gtsam_unstable/slam/InvDepthFactorVariant3.h
@@ -35,6 +35,7 @@ public:
 
   /// shorthand for base class type
   typedef NoiseModelFactor2<Pose3, Vector3> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// shorthand for this class

--- a/gtsam_unstable/slam/LocalOrientedPlane3Factor.cpp
+++ b/gtsam_unstable/slam/LocalOrientedPlane3Factor.cpp
@@ -24,8 +24,8 @@ void LocalOrientedPlane3Factor::print(const string& s,
 //***************************************************************************
 Vector LocalOrientedPlane3Factor::evaluateError(const Pose3& wTwi,
     const Pose3& wTwa, const OrientedPlane3& a_plane,
-    boost::optional<Matrix&> H1, boost::optional<Matrix&> H2,
-    boost::optional<Matrix&> H3) const {
+    OptionalMatrixType H1, OptionalMatrixType H2,
+    OptionalMatrixType H3) const {
 
   Matrix66 aTai_H_wTwa, aTai_H_wTwi;
   Matrix36 predicted_H_aTai;

--- a/gtsam_unstable/slam/LocalOrientedPlane3Factor.h
+++ b/gtsam_unstable/slam/LocalOrientedPlane3Factor.h
@@ -40,6 +40,7 @@ class GTSAM_UNSTABLE_EXPORT LocalOrientedPlane3Factor
   OrientedPlane3 measured_p_;
   typedef NoiseModelFactorN<Pose3, Pose3, OrientedPlane3> Base;
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /// Constructor
   LocalOrientedPlane3Factor() {}

--- a/gtsam_unstable/slam/LocalOrientedPlane3Factor.h
+++ b/gtsam_unstable/slam/LocalOrientedPlane3Factor.h
@@ -40,6 +40,7 @@ class GTSAM_UNSTABLE_EXPORT LocalOrientedPlane3Factor
   OrientedPlane3 measured_p_;
   typedef NoiseModelFactorN<Pose3, Pose3, OrientedPlane3> Base;
 public:
+  using Base::evaluateError;
   /// Constructor
   LocalOrientedPlane3Factor() {}
 
@@ -84,10 +85,8 @@ public:
     * world frame.
     */
   Vector evaluateError(const Pose3& wTwi, const Pose3& wTwa,
-      const OrientedPlane3& a_plane,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override;
+      const OrientedPlane3& a_plane, OptionalMatrixType H1, 
+	  OptionalMatrixType H2, OptionalMatrixType H3) const override;
 };
 
 }  // namespace gtsam

--- a/gtsam_unstable/slam/LocalOrientedPlane3Factor.h
+++ b/gtsam_unstable/slam/LocalOrientedPlane3Factor.h
@@ -40,6 +40,7 @@ class GTSAM_UNSTABLE_EXPORT LocalOrientedPlane3Factor
   OrientedPlane3 measured_p_;
   typedef NoiseModelFactorN<Pose3, Pose3, OrientedPlane3> Base;
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/LocalOrientedPlane3Factor.h
+++ b/gtsam_unstable/slam/LocalOrientedPlane3Factor.h
@@ -42,6 +42,7 @@ class GTSAM_UNSTABLE_EXPORT LocalOrientedPlane3Factor
 public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /// Constructor
   LocalOrientedPlane3Factor() {}
 

--- a/gtsam_unstable/slam/MultiProjectionFactor.h
+++ b/gtsam_unstable/slam/MultiProjectionFactor.h
@@ -129,7 +129,7 @@ namespace gtsam {
     }
 
     /// Evaluate error h(x)-z and optionally derivatives
-    Vector unwhitenedError(const Values& x, boost::optional<std::vector<Matrix>&> H = boost::none) const override {
+    Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalNone) const override {
 
       Vector a;
       return a;

--- a/gtsam_unstable/slam/MultiProjectionFactor.h
+++ b/gtsam_unstable/slam/MultiProjectionFactor.h
@@ -130,7 +130,7 @@ namespace gtsam {
     }
 
     /// Evaluate error h(x)-z and optionally derivatives
-    Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const override {
+    Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = nullptr) const override {
 
       Vector a;
       return a;

--- a/gtsam_unstable/slam/MultiProjectionFactor.h
+++ b/gtsam_unstable/slam/MultiProjectionFactor.h
@@ -129,7 +129,7 @@ namespace gtsam {
     }
 
     /// Evaluate error h(x)-z and optionally derivatives
-    Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalNone) const override {
+    Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const override {
 
       Vector a;
       return a;

--- a/gtsam_unstable/slam/MultiProjectionFactor.h
+++ b/gtsam_unstable/slam/MultiProjectionFactor.h
@@ -23,6 +23,7 @@
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/geometry/PinholeCamera.h>
 #include <boost/optional.hpp>
+#include "gtsam/geometry/Cal3_S2.h"
 
 namespace gtsam {
 
@@ -164,7 +165,7 @@ namespace gtsam {
 
 
     Vector evaluateError(const Pose3& pose, const Point3& point,
-        boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 = boost::none) const {
+        OptionalJacobian<2, 6> H1 = {}, OptionalJacobian<2,3> H2 = {}) const {
       try {
         if(body_P_sensor_) {
           if(H1) {

--- a/gtsam_unstable/slam/PartialPriorFactor.h
+++ b/gtsam_unstable/slam/PartialPriorFactor.h
@@ -61,6 +61,7 @@ namespace gtsam {
       : Base(model, key) {}
 
   public:
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
     ~PartialPriorFactor() override {}

--- a/gtsam_unstable/slam/PartialPriorFactor.h
+++ b/gtsam_unstable/slam/PartialPriorFactor.h
@@ -61,6 +61,7 @@ namespace gtsam {
       : Base(model, key) {}
 
   public:
+
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 

--- a/gtsam_unstable/slam/PartialPriorFactor.h
+++ b/gtsam_unstable/slam/PartialPriorFactor.h
@@ -61,6 +61,7 @@ namespace gtsam {
       : Base(model, key) {}
 
   public:
+    using Base::evaluateError;
 
     ~PartialPriorFactor() override {}
 
@@ -106,7 +107,7 @@ namespace gtsam {
     /** implement functions needed to derive from Factor */
 
     /** Returns a vector of errors for the measured tangent parameters.  */
-    Vector evaluateError(const T& p, boost::optional<Matrix&> H = boost::none) const override {
+    Vector evaluateError(const T& p, OptionalMatrixType H) const override {
       Eigen::Matrix<double, T::dimension, T::dimension> H_local;
 
       // If the Rot3 Cayley map is used, Rot3::LocalCoordinates will throw a runtime error

--- a/gtsam_unstable/slam/PoseBetweenFactor.h
+++ b/gtsam_unstable/slam/PoseBetweenFactor.h
@@ -43,6 +43,7 @@ namespace gtsam {
     GTSAM_CONCEPT_TESTABLE_TYPE(POSE)
     GTSAM_CONCEPT_POSE_TYPE(POSE)
   public:
+
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 

--- a/gtsam_unstable/slam/PoseBetweenFactor.h
+++ b/gtsam_unstable/slam/PoseBetweenFactor.h
@@ -43,6 +43,7 @@ namespace gtsam {
     GTSAM_CONCEPT_TESTABLE_TYPE(POSE)
     GTSAM_CONCEPT_POSE_TYPE(POSE)
   public:
+    using Base::evaluateError;
 
     // shorthand for a smart pointer to a factor
     typedef typename boost::shared_ptr<PoseBetweenFactor> shared_ptr;
@@ -89,8 +90,7 @@ namespace gtsam {
 
     /** vector of errors */
     Vector evaluateError(const POSE& p1, const POSE& p2,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2) const override {
       if(body_P_sensor_) {
         POSE hx;
         if(H1 || H2) {

--- a/gtsam_unstable/slam/PoseBetweenFactor.h
+++ b/gtsam_unstable/slam/PoseBetweenFactor.h
@@ -43,6 +43,7 @@ namespace gtsam {
     GTSAM_CONCEPT_TESTABLE_TYPE(POSE)
     GTSAM_CONCEPT_POSE_TYPE(POSE)
   public:
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
     // shorthand for a smart pointer to a factor

--- a/gtsam_unstable/slam/PosePriorFactor.h
+++ b/gtsam_unstable/slam/PosePriorFactor.h
@@ -40,6 +40,7 @@ namespace gtsam {
     GTSAM_CONCEPT_TESTABLE_TYPE(POSE)
     GTSAM_CONCEPT_POSE_TYPE(POSE)
   public:
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
     /// shorthand for a smart pointer to a factor

--- a/gtsam_unstable/slam/PosePriorFactor.h
+++ b/gtsam_unstable/slam/PosePriorFactor.h
@@ -40,6 +40,7 @@ namespace gtsam {
     GTSAM_CONCEPT_TESTABLE_TYPE(POSE)
     GTSAM_CONCEPT_POSE_TYPE(POSE)
   public:
+
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 

--- a/gtsam_unstable/slam/PosePriorFactor.h
+++ b/gtsam_unstable/slam/PosePriorFactor.h
@@ -40,6 +40,7 @@ namespace gtsam {
     GTSAM_CONCEPT_TESTABLE_TYPE(POSE)
     GTSAM_CONCEPT_POSE_TYPE(POSE)
   public:
+    using Base::evaluateError;
 
     /// shorthand for a smart pointer to a factor
     typedef typename boost::shared_ptr<PosePriorFactor<POSE> > shared_ptr;
@@ -83,7 +84,7 @@ namespace gtsam {
     /** implement functions needed to derive from Factor */
 
     /** vector of errors */
-    Vector evaluateError(const POSE& p, boost::optional<Matrix&> H = boost::none) const override {
+    Vector evaluateError(const POSE& p, OptionalMatrixType H) const override {
       if(body_P_sensor_) {
         // manifold equivalent of h(x)-z -> log(z,h(x))
         return prior_.localCoordinates(p.compose(*body_P_sensor_, H));

--- a/gtsam_unstable/slam/PoseToPointFactor.h
+++ b/gtsam_unstable/slam/PoseToPointFactor.h
@@ -29,6 +29,8 @@ class PoseToPointFactor : public NoiseModelFactorN<POSE, POINT> {
   POINT measured_; /** the point measurement in local coordinates */
 
  public:
+
+  using Base::evaluateError;
   // shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<PoseToPointFactor> shared_ptr;
 
@@ -79,8 +81,8 @@ class PoseToPointFactor : public NoiseModelFactorN<POSE, POINT> {
    */
   Vector evaluateError(
       const POSE& w_T_b, const POINT& w_P,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1,
+      OptionalMatrixType H2) const override {
     return w_T_b.transformTo(w_P, H1, H2) - measured_;
   }
 

--- a/gtsam_unstable/slam/PoseToPointFactor.h
+++ b/gtsam_unstable/slam/PoseToPointFactor.h
@@ -29,7 +29,7 @@ class PoseToPointFactor : public NoiseModelFactorN<POSE, POINT> {
   POINT measured_; /** the point measurement in local coordinates */
 
  public:
-
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   // shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<PoseToPointFactor> shared_ptr;

--- a/gtsam_unstable/slam/PoseToPointFactor.h
+++ b/gtsam_unstable/slam/PoseToPointFactor.h
@@ -31,6 +31,7 @@ class PoseToPointFactor : public NoiseModelFactorN<POSE, POINT> {
  public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   // shorthand for a smart pointer to a factor
   typedef boost::shared_ptr<PoseToPointFactor> shared_ptr;
 

--- a/gtsam_unstable/slam/PoseToPointFactor.h
+++ b/gtsam_unstable/slam/PoseToPointFactor.h
@@ -29,6 +29,7 @@ class PoseToPointFactor : public NoiseModelFactorN<POSE, POINT> {
   POINT measured_; /** the point measurement in local coordinates */
 
  public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/ProjectionFactorPPP.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPP.h
@@ -45,7 +45,8 @@ namespace gtsam {
   public:
 
     /// shorthand for base class type
-    typedef NoiseModelFactorN<POSE, POSE, LANDMARK> Base;
+    typedef NoiseModelFactor3<POSE, POSE, LANDMARK> Base;
+    using Base::evaluateError;
 
     /// shorthand for this class
     typedef ProjectionFactorPPP<POSE, LANDMARK, CALIBRATION> This;
@@ -122,9 +123,7 @@ namespace gtsam {
 
     /// Evaluate error h(x)-z and optionally derivatives
     Vector evaluateError(const Pose3& pose, const Pose3& transform, const Point3& point,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none,
-        boost::optional<Matrix&> H3 = boost::none) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3) const override {
       try {
           if(H1 || H2 || H3) {
             Matrix H0, H02;

--- a/gtsam_unstable/slam/ProjectionFactorPPP.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPP.h
@@ -46,6 +46,7 @@ namespace gtsam {
 
     /// shorthand for base class type
     typedef NoiseModelFactor3<POSE, POSE, LANDMARK> Base;
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
     /// shorthand for this class

--- a/gtsam_unstable/slam/ProjectionFactorPPP.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPP.h
@@ -46,6 +46,7 @@ namespace gtsam {
 
     /// shorthand for base class type
     typedef NoiseModelFactor3<POSE, POSE, LANDMARK> Base;
+
     // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 

--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -45,6 +45,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
  public:
   /// shorthand for base class type
   typedef NoiseModelFactor4<POSE, POSE, LANDMARK, CALIBRATION> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// shorthand for this class

--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -45,6 +45,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
  public:
   /// shorthand for base class type
   typedef NoiseModelFactor4<POSE, POSE, LANDMARK, CALIBRATION> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/ProjectionFactorPPPC.h
+++ b/gtsam_unstable/slam/ProjectionFactorPPPC.h
@@ -44,7 +44,8 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
 
  public:
   /// shorthand for base class type
-  typedef NoiseModelFactorN<POSE, POSE, LANDMARK, CALIBRATION> Base;
+  typedef NoiseModelFactor4<POSE, POSE, LANDMARK, CALIBRATION> Base;
+  using Base::evaluateError;
 
   /// shorthand for this class
   typedef ProjectionFactorPPPC<POSE, LANDMARK, CALIBRATION> This;
@@ -108,10 +109,8 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorPPPC
 
     /// Evaluate error h(x)-z and optionally derivatives
     Vector evaluateError(const Pose3& pose, const Pose3& transform, const Point3& point, const CALIBRATION& K,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none,
-        boost::optional<Matrix&> H3 = boost::none,
-        boost::optional<Matrix&> H4 = boost::none) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3,
+        OptionalMatrixType H4) const override {
       try {
           if(H1 || H2 || H3 || H4) {
             Matrix H0, H02;

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.cpp
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.cpp
@@ -21,8 +21,8 @@ namespace gtsam {
 
 Vector ProjectionFactorRollingShutter::evaluateError(
     const Pose3& pose_a, const Pose3& pose_b, const Point3& point,
-    boost::optional<Matrix&> H1, boost::optional<Matrix&> H2,
-    boost::optional<Matrix&> H3) const {
+    OptionalMatrixType H1, OptionalMatrixType H2,
+    OptionalMatrixType H3) const {
   try {
     Pose3 pose = interpolate<Pose3>(pose_a, pose_b, alpha_, H1, H2);
     gtsam::Matrix Hprj;

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
@@ -61,6 +61,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorRollingShutter
  public:
   /// shorthand for base class type
   typedef NoiseModelFactor3<Pose3, Pose3, Point3> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// shorthand for this class

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
@@ -61,6 +61,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorRollingShutter
  public:
   /// shorthand for base class type
   typedef NoiseModelFactor3<Pose3, Pose3, Point3> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
@@ -60,7 +60,8 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorRollingShutter
 
  public:
   /// shorthand for base class type
-  typedef NoiseModelFactorN<Pose3, Pose3, Point3> Base;
+  typedef NoiseModelFactor3<Pose3, Pose3, Point3> Base;
+  using Base::evaluateError;
 
   /// shorthand for this class
   typedef ProjectionFactorRollingShutter This;
@@ -173,9 +174,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorRollingShutter
   /// Evaluate error h(x)-z and optionally derivatives
   Vector evaluateError(
       const Pose3& pose_a, const Pose3& pose_b, const Point3& point,
-      boost::optional<Matrix&> H1 = boost::none,
-      boost::optional<Matrix&> H2 = boost::none,
-      boost::optional<Matrix&> H3 = boost::none) const override;
+      OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3) const override;
 
   /** return the measurement */
   const Point2& measured() const { return measured_; }

--- a/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
+++ b/gtsam_unstable/slam/ProjectionFactorRollingShutter.h
@@ -64,6 +64,7 @@ class GTSAM_UNSTABLE_EXPORT ProjectionFactorRollingShutter
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
+
   /// shorthand for this class
   typedef ProjectionFactorRollingShutter This;
 

--- a/gtsam_unstable/slam/RelativeElevationFactor.cpp
+++ b/gtsam_unstable/slam/RelativeElevationFactor.cpp
@@ -18,7 +18,7 @@ RelativeElevationFactor::RelativeElevationFactor(Key poseKey, Key pointKey, doub
 
 /* ************************************************************************* */
 Vector RelativeElevationFactor::evaluateError(const Pose3& pose, const Point3& point,
-    boost::optional<Matrix&> H1, boost::optional<Matrix&> H2) const {
+    OptionalMatrixType H1, OptionalMatrixType H2) const {
   double hx = pose.z() - point.z();
   if (H1) {
     *H1 = Matrix::Zero(1,6);

--- a/gtsam_unstable/slam/RelativeElevationFactor.h
+++ b/gtsam_unstable/slam/RelativeElevationFactor.h
@@ -34,6 +34,7 @@ private:
   typedef NoiseModelFactorN<Pose3, Point3> Base;
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/RelativeElevationFactor.h
+++ b/gtsam_unstable/slam/RelativeElevationFactor.h
@@ -34,6 +34,7 @@ private:
   typedef NoiseModelFactorN<Pose3, Point3> Base;
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   RelativeElevationFactor() : measured_(0.0) {} /* Default constructor */

--- a/gtsam_unstable/slam/RelativeElevationFactor.h
+++ b/gtsam_unstable/slam/RelativeElevationFactor.h
@@ -34,6 +34,7 @@ private:
   typedef NoiseModelFactorN<Pose3, Point3> Base;
 
 public:
+  using Base::evaluateError;
 
   RelativeElevationFactor() : measured_(0.0) {} /* Default constructor */
 
@@ -49,7 +50,7 @@ public:
 
   /** h(x)-z */
   Vector evaluateError(const Pose3& pose, const Point3& point,
-      boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 = boost::none) const override;
+      OptionalMatrixType H1, OptionalMatrixType H2) const override;
 
   /** return the measured */
   inline double measured() const { return measured_; }

--- a/gtsam_unstable/slam/SmartRangeFactor.h
+++ b/gtsam_unstable/slam/SmartRangeFactor.h
@@ -42,7 +42,9 @@ class SmartRangeFactor: public NoiseModelFactor {
   double variance_;  ///< variance on noise
 
  public:
+  // Provide access to the Matrix& version of unwhitenedError
   using NoiseModelFactor::unwhitenedError;
+
   /** Default constructor: don't use directly */
   SmartRangeFactor() {
   }

--- a/gtsam_unstable/slam/SmartRangeFactor.h
+++ b/gtsam_unstable/slam/SmartRangeFactor.h
@@ -42,6 +42,7 @@ class SmartRangeFactor: public NoiseModelFactor {
   double variance_;  ///< variance on noise
 
  public:
+
   // Provide access to the Matrix& version of unwhitenedError
   using NoiseModelFactor::unwhitenedError;
 

--- a/gtsam_unstable/slam/SmartRangeFactor.h
+++ b/gtsam_unstable/slam/SmartRangeFactor.h
@@ -42,6 +42,7 @@ class SmartRangeFactor: public NoiseModelFactor {
   double variance_;  ///< variance on noise
 
  public:
+  using NoiseModelFactor::unwhitenedError;
   /** Default constructor: don't use directly */
   SmartRangeFactor() {
   }
@@ -143,8 +144,7 @@ class SmartRangeFactor: public NoiseModelFactor {
   /**
    * Error function *without* the NoiseModel, \f$ z-h(x) \f$.
    */
-  Vector unwhitenedError(const Values& x,
-      boost::optional<std::vector<Matrix>&> H = boost::none) const override {
+  Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const override {
     size_t n = size();
     if (n < 3) {
       if (H) {

--- a/gtsam_unstable/slam/SmartRangeFactor.h
+++ b/gtsam_unstable/slam/SmartRangeFactor.h
@@ -146,7 +146,7 @@ class SmartRangeFactor: public NoiseModelFactor {
   /**
    * Error function *without* the NoiseModel, \f$ z-h(x) \f$.
    */
-  Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const override {
+  Vector unwhitenedError(const Values& x, OptionalMatrixVecType H = nullptr) const override {
     size_t n = size();
     if (n < 3) {
       if (H) {

--- a/gtsam_unstable/slam/SmartStereoProjectionFactor.h
+++ b/gtsam_unstable/slam/SmartStereoProjectionFactor.h
@@ -340,7 +340,7 @@ public:
   bool triangulateAndComputeE(Matrix& E, const Cameras& cameras) const {
     bool nonDegenerate = triangulateForLinearize(cameras);
     if (nonDegenerate)
-      cameras.project2(*result_, boost::none, E);
+      cameras.project2(*result_, nullptr, &E);
     return nonDegenerate;
   }
 
@@ -453,8 +453,8 @@ public:
    */
   void correctForMissingMeasurements(
       const Cameras& cameras, Vector& ue,
-      boost::optional<typename Cameras::FBlocks&> Fs = boost::none,
-      boost::optional<Matrix&> E = boost::none) const override {
+      typename Cameras::FBlocks* Fs = nullptr,
+      Matrix* E = nullptr) const override {
     // when using stereo cameras, some of the measurements might be missing:
     for (size_t i = 0; i < cameras.size(); i++) {
       const StereoPoint2& z = measured_.at(i);

--- a/gtsam_unstable/slam/TSAMFactors.h
+++ b/gtsam_unstable/slam/TSAMFactors.h
@@ -37,6 +37,7 @@ private:
   Point2 measured_; ///< the measurement
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -67,6 +68,7 @@ private:
   Point2 measured_; ///< the measurement
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -122,6 +124,7 @@ private:
   Pose2 measured_; ///< the measurement
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/gtsam_unstable/slam/TSAMFactors.h
+++ b/gtsam_unstable/slam/TSAMFactors.h
@@ -69,6 +69,7 @@ private:
 public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   /// Constructor
   DeltaFactorBase(Key b1, Key i, Key b2, Key j, const Point2& measured,
       const SharedNoiseModel& model) :

--- a/gtsam_unstable/slam/TSAMFactors.h
+++ b/gtsam_unstable/slam/TSAMFactors.h
@@ -37,6 +37,7 @@ private:
   Point2 measured_; ///< the measurement
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// Constructor
@@ -66,6 +67,7 @@ private:
   Point2 measured_; ///< the measurement
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   /// Constructor
   DeltaFactorBase(Key b1, Key i, Key b2, Key j, const Point2& measured,
@@ -119,6 +121,7 @@ private:
   Pose2 measured_; ///< the measurement
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   /// Constructor

--- a/gtsam_unstable/slam/TSAMFactors.h
+++ b/gtsam_unstable/slam/TSAMFactors.h
@@ -37,6 +37,7 @@ private:
   Point2 measured_; ///< the measurement
 
 public:
+  using Base::evaluateError;
 
   /// Constructor
   DeltaFactor(Key i, Key j, const Point2& measured,
@@ -46,8 +47,7 @@ public:
 
   /// Evaluate measurement error h(x)-z
   Vector evaluateError(const Pose2& pose, const Point2& point,
-      boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 =
-          boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     return pose.transformTo(point, H1, H2) - measured_;
   }
 };
@@ -66,7 +66,7 @@ private:
   Point2 measured_; ///< the measurement
 
 public:
-
+  using Base::evaluateError;
   /// Constructor
   DeltaFactorBase(Key b1, Key i, Key b2, Key j, const Point2& measured,
       const SharedNoiseModel& model) :
@@ -76,10 +76,8 @@ public:
   /// Evaluate measurement error h(x)-z
   Vector evaluateError(const Pose2& base1, const Pose2& pose,
       const Pose2& base2, const Point2& point, //
-      boost::optional<Matrix&> H1 = boost::none, //
-      boost::optional<Matrix&> H2 = boost::none, //
-      boost::optional<Matrix&> H3 = boost::none, //
-      boost::optional<Matrix&> H4 = boost::none) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2, //
+      OptionalMatrixType H3, OptionalMatrixType H4) const override {
     if (H1 || H2 || H3 || H4) {
       // TODO use fixed-size matrices
       Matrix D_pose_g_base1, D_pose_g_pose;
@@ -121,6 +119,7 @@ private:
   Pose2 measured_; ///< the measurement
 
 public:
+  using Base::evaluateError;
 
   /// Constructor
   OdometryFactorBase(Key b1, Key i, Key b2, Key j, const Pose2& measured,
@@ -130,11 +129,9 @@ public:
 
   /// Evaluate measurement error h(x)-z
   Vector evaluateError(const Pose2& base1, const Pose2& pose1,
-      const Pose2& base2, const Pose2& pose2, //
-      boost::optional<Matrix&> H1 = boost::none, //
-      boost::optional<Matrix&> H2 = boost::none, //
-      boost::optional<Matrix&> H3 = boost::none, //
-      boost::optional<Matrix&> H4 = boost::none) const override {
+      const Pose2& base2, const Pose2& pose2,
+      OptionalMatrixType H1, OptionalMatrixType H2,
+      OptionalMatrixType H3, OptionalMatrixType H4) const override {
     if (H1 || H2 || H3 || H4) {
       // TODO use fixed-size matrices
       Matrix D_pose1_g_base1, D_pose1_g_pose1;

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
@@ -186,6 +186,9 @@ namespace gtsam {
     }
 
     /* ************************************************************************* */
+    /** A function overload to accept a vector<matrix> instead of a pointer to
+     * the said type.
+     */
     gtsam::Vector whitenedError(const gtsam::Values& x, std::vector<Matrix>& H) const {
 	  return whitenedError(x, &H);
     }

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
@@ -156,8 +156,7 @@ namespace gtsam {
 
 
     /* ************************************************************************* */
-    gtsam::Vector whitenedError(const gtsam::Values& x,
-        boost::optional<std::vector<gtsam::Matrix>&> H = boost::none) const {
+    gtsam::Vector whitenedError(const gtsam::Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const {
 
       T orgA_T_currA = valA_.at<T>(keyA_);
       T orgB_T_currB = valB_.at<T>(keyB_);
@@ -185,6 +184,13 @@ namespace gtsam {
 
       return error;
     }
+
+    /* ************************************************************************* */
+#ifdef NO_BOOST_CPP17
+    gtsam::Vector whitenedError(const gtsam::Values& x, std::vector<Matrix>& H) const {
+	  return whitenedError(x, &H);
+    }
+#endif
 
 
     /* ************************************************************************* */

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
@@ -186,11 +186,9 @@ namespace gtsam {
     }
 
     /* ************************************************************************* */
-#ifdef NO_BOOST_CPP17
     gtsam::Vector whitenedError(const gtsam::Values& x, std::vector<Matrix>& H) const {
 	  return whitenedError(x, &H);
     }
-#endif
 
 
     /* ************************************************************************* */

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactor.h
@@ -156,7 +156,7 @@ namespace gtsam {
 
 
     /* ************************************************************************* */
-    gtsam::Vector whitenedError(const gtsam::Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const {
+    gtsam::Vector whitenedError(const gtsam::Values& x, OptionalMatrixVecType H = nullptr) const {
 
       T orgA_T_currA = valA_.at<T>(keyA_);
       T orgB_T_currB = valB_.at<T>(keyB_);

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
@@ -179,6 +179,9 @@ namespace gtsam {
 
 
     /* ************************************************************************* */
+    /** A function overload to accept a vector<matrix> instead of a pointer to
+     * the said type.
+     */
     Vector whitenedError(const Values& x, OptionalMatrixVecType H = nullptr) const {
 
       bool debug = true;

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
@@ -179,7 +179,7 @@ namespace gtsam {
 
 
     /* ************************************************************************* */
-    Vector whitenedError(const Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const {
+    Vector whitenedError(const Values& x, OptionalMatrixVecType H = nullptr) const {
 
       bool debug = true;
 

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
@@ -245,9 +245,9 @@ namespace gtsam {
     }
     
     /* ************************************************************************* */
-	Vector whitenedError(const Values& x, std::vector<Matrix>& H) const {
-	  return whitenedError(x, &H);
-	}
+    Vector whitenedError(const Values& x, std::vector<Matrix>& H) const {
+      return whitenedError(x, &H);
+    }
 
     /* ************************************************************************* */
     Vector calcIndicatorProb(const Values& x) const {

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
@@ -179,8 +179,7 @@ namespace gtsam {
 
 
     /* ************************************************************************* */
-    Vector whitenedError(const Values& x,
-        boost::optional<std::vector<Matrix>&> H = boost::none) const {
+    Vector whitenedError(const Values& x, OptionalMatrixVecType H = OptionalMatrixVecNone) const {
 
       bool debug = true;
 
@@ -244,6 +243,13 @@ namespace gtsam {
 
       return err_wh_eq;
     }
+    
+    /* ************************************************************************* */
+#ifdef NO_BOOST_CPP17
+	Vector whitenedError(const Values& x, std::vector<Matrix>& H) const {
+	  return whitenedError(x, &H);
+	}
+#endif
 
     /* ************************************************************************* */
     Vector calcIndicatorProb(const Values& x) const {

--- a/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
+++ b/gtsam_unstable/slam/TransformBtwRobotsUnaryFactorEM.h
@@ -245,11 +245,9 @@ namespace gtsam {
     }
     
     /* ************************************************************************* */
-#ifdef NO_BOOST_CPP17
 	Vector whitenedError(const Values& x, std::vector<Matrix>& H) const {
 	  return whitenedError(x, &H);
 	}
-#endif
 
     /* ************************************************************************* */
     Vector calcIndicatorProb(const Values& x) const {

--- a/gtsam_unstable/slam/tests/testBiasedGPSFactor.cpp
+++ b/gtsam_unstable/slam/tests/testBiasedGPSFactor.cpp
@@ -66,18 +66,13 @@ TEST(BiasedGPSFactor, jacobian) {
   Matrix actualH1, actualH2;
   factor.evaluateError(pose,bias, actualH1, actualH2);
 
-  Matrix numericalH1 = numericalDerivative21(
-      std::function<Vector(const Pose3&, const Point3&)>(std::bind(
-          &BiasedGPSFactor::evaluateError, factor, std::placeholders::_1,
-          std::placeholders::_2, boost::none, boost::none)),
-      pose, bias, 1e-5);
+  std::function<Vector(const Pose3&, const Point3&)> f = [&factor](const Pose3& pose, const Point3& bias) {
+    return factor.evaluateError(pose, bias);
+  };
+  Matrix numericalH1 = numericalDerivative21(f, pose, bias, 1e-5);
   EXPECT(assert_equal(numericalH1,actualH1, 1E-5));
 
-  Matrix numericalH2 = numericalDerivative22(
-      std::function<Vector(const Pose3&, const Point3&)>(std::bind(
-          &BiasedGPSFactor::evaluateError, factor, std::placeholders::_1,
-          std::placeholders::_2, boost::none, boost::none)),
-      pose, bias, 1e-5);
+  Matrix numericalH2 = numericalDerivative22(f, pose, bias, 1e-5);
   EXPECT(assert_equal(numericalH2,actualH2, 1E-5));
 }
 

--- a/gtsam_unstable/slam/tests/testLocalOrientedPlane3Factor.cpp
+++ b/gtsam_unstable/slam/tests/testLocalOrientedPlane3Factor.cpp
@@ -23,6 +23,9 @@
 #include <gtsam/nonlinear/ISAM2.h>
 
 #include <CppUnitLite/TestHarness.h>
+#include "gtsam/base/Vector.h"
+#include "gtsam/geometry/OrientedPlane3.h"
+#include "gtsam/geometry/Pose3.h"
 
 using namespace std::placeholders;
 using namespace gtsam;
@@ -141,10 +144,10 @@ TEST(LocalOrientedPlane3Factor, Derivatives) {
   LocalOrientedPlane3Factor factor(p, noise, poseKey, anchorPoseKey, planeKey);
 
   // Calculate numerical derivatives
-  auto f =
-      std::bind(&LocalOrientedPlane3Factor::evaluateError, factor,
-                std::placeholders::_1, std::placeholders::_2,
-                std::placeholders::_3, boost::none, boost::none, boost::none);
+  auto f = [&factor] (const Pose3& p1, const Pose3& p2, const OrientedPlane3& a_plane) {
+	  return factor.evaluateError(p1, p2, a_plane);
+  };
+
   Matrix numericalH1 = numericalDerivative31<Vector3, Pose3, Pose3,
     OrientedPlane3>(f, poseLin, anchorPoseLin, pLin);
   Matrix numericalH2 = numericalDerivative32<Vector3, Pose3, Pose3,

--- a/gtsam_unstable/slam/tests/testPartialPriorFactor.cpp
+++ b/gtsam_unstable/slam/tests/testPartialPriorFactor.cpp
@@ -82,9 +82,7 @@ TEST(PartialPriorFactor, JacobianPartialTranslation2) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose2>(
-      std::bind(&TestPartialPriorFactor2::evaluateError, &factor,
-                std::placeholders::_1, boost::none),
-      pose);
+		  [&factor](const Pose2& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -107,9 +105,7 @@ TEST(PartialPriorFactor, JacobianFullTranslation2) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose2>(
-      std::bind(&TestPartialPriorFactor2::evaluateError, &factor,
-                std::placeholders::_1, boost::none),
-      pose);
+		  [&factor](const Pose2& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -131,7 +127,7 @@ TEST(PartialPriorFactor, JacobianTheta) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose2>(
-      std::bind(&TestPartialPriorFactor2::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
+		  [&factor](const Pose2& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -182,7 +178,7 @@ TEST(PartialPriorFactor, JacobianAtIdentity3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
+		  [&factor](const Pose3& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -204,7 +200,7 @@ TEST(PartialPriorFactor, JacobianPartialTranslation3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
+		  [&factor](const Pose3& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -228,7 +224,7 @@ TEST(PartialPriorFactor, JacobianFullTranslation3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
+		  [&factor](const Pose3& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -252,7 +248,7 @@ TEST(PartialPriorFactor, JacobianTxTz3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
+		  [&factor](const Pose3& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;
@@ -275,7 +271,7 @@ TEST(PartialPriorFactor, JacobianFullRotation3) {
 
   // Calculate numerical derivatives.
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPartialPriorFactor3::evaluateError, &factor, std::placeholders::_1, boost::none), pose);
+		  [&factor](const Pose3& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative.
   Matrix actualH1;

--- a/gtsam_unstable/slam/tests/testPoseBetweenFactor.cpp
+++ b/gtsam_unstable/slam/tests/testPoseBetweenFactor.cpp
@@ -199,13 +199,9 @@ TEST( PoseBetweenFactor, Jacobian ) {
 
   // Calculate numerical derivatives
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPoseBetweenFactor::evaluateError, &factor,
-                std::placeholders::_1, pose2, boost::none, boost::none),
-      pose1);
+		  [&factor, &pose2](const Pose3& p) { return factor.evaluateError(p, pose2); }, pose1);
   Matrix expectedH2 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPoseBetweenFactor::evaluateError, &factor, pose1,
-                std::placeholders::_1, boost::none, boost::none),
-      pose2);
+		  [&factor, &pose1](const Pose3& p) { return factor.evaluateError(pose1, p); }, pose2);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;
@@ -234,13 +230,9 @@ TEST( PoseBetweenFactor, JacobianWithTransform ) {
 
   // Calculate numerical derivatives
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPoseBetweenFactor::evaluateError, &factor,
-                std::placeholders::_1, pose2, boost::none, boost::none),
-      pose1);
+		  [&factor, &pose2](const Pose3& p) { return factor.evaluateError(p, pose2); }, pose1);
   Matrix expectedH2 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPoseBetweenFactor::evaluateError, &factor, pose1,
-                std::placeholders::_1, boost::none, boost::none),
-      pose2);
+		  [&factor, &pose1](const Pose3& p) { return factor.evaluateError(pose1, p); }, pose2);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;

--- a/gtsam_unstable/slam/tests/testPosePriorFactor.cpp
+++ b/gtsam_unstable/slam/tests/testPosePriorFactor.cpp
@@ -188,9 +188,7 @@ TEST( PosePriorFactor, Jacobian ) {
 
   // Calculate numerical derivatives
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPosePriorFactor::evaluateError, &factor,
-                std::placeholders::_1, boost::none),
-      pose);
+		  [&factor](const Pose3& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;
@@ -215,9 +213,7 @@ TEST( PosePriorFactor, JacobianWithTransform ) {
 
   // Calculate numerical derivatives
   Matrix expectedH1 = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestPosePriorFactor::evaluateError, &factor,
-                std::placeholders::_1, boost::none),
-      pose);
+		  [&factor](const Pose3& p) { return factor.evaluateError(p); }, pose);
 
   // Use the factor to calculate the derivative
   Matrix actualH1;

--- a/gtsam_unstable/slam/tests/testPoseToPointFactor.cpp
+++ b/gtsam_unstable/slam/tests/testPoseToPointFactor.cpp
@@ -67,9 +67,9 @@ TEST(PoseToPointFactor, jacobian_2D) {
   PoseToPointFactor<Pose2,Point2> factor(pose_key, point_key, l_meas, noise);
 
   // Calculate numerical derivatives
-  auto f = std::bind(&PoseToPointFactor<Pose2,Point2>::evaluateError, factor,
-                     std::placeholders::_1, std::placeholders::_2, boost::none,
-                     boost::none);
+  auto f = [&factor] (const Pose2& pose, const Point2& pt) {
+	  return factor.evaluateError(pose, pt);
+  };
   Matrix numerical_H1 = numericalDerivative21<Vector, Pose2, Point2>(f, p, l);
   Matrix numerical_H2 = numericalDerivative22<Vector, Pose2, Point2>(f, p, l);
 
@@ -137,9 +137,10 @@ TEST(PoseToPointFactor, jacobian_3D) {
   PoseToPointFactor<Pose3,Point3> factor(pose_key, point_key, l_meas, noise);
 
   // Calculate numerical derivatives
-  auto f = std::bind(&PoseToPointFactor<Pose3,Point3>::evaluateError, factor,
-                     std::placeholders::_1, std::placeholders::_2, boost::none,
-                     boost::none);
+  auto f = [&factor] (const Pose3& pose, const Point3& pt) {
+	  return factor.evaluateError(pose, pt);
+  };
+
   Matrix numerical_H1 = numericalDerivative21<Vector, Pose3, Point3>(f, p, l);
   Matrix numerical_H2 = numericalDerivative22<Vector, Pose3, Point3>(f, p, l);
 

--- a/gtsam_unstable/slam/tests/testProjectionFactorPPP.cpp
+++ b/gtsam_unstable/slam/tests/testProjectionFactorPPP.cpp
@@ -177,11 +177,9 @@ TEST( ProjectionFactorPPP, Jacobian ) {
 
   // Verify H2 with numerical derivative
   Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
-      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-          std::bind(&TestProjectionFactor::evaluateError, &factor,
-                    std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, boost::none, boost::none,
-                    boost::none)),
+      [&factor](const Pose3& pose, const Pose3& transform, const Point3& point) {
+        return factor.evaluateError(pose, transform, point);
+      },
       pose, Pose3(), point);
 
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
@@ -215,11 +213,9 @@ TEST( ProjectionFactorPPP, JacobianWithTransform ) {
 
   // Verify H2 with numerical derivative
   Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
-      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-          std::bind(&TestProjectionFactor::evaluateError, &factor,
-                    std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, boost::none, boost::none,
-                    boost::none)),
+      [&factor](const Pose3& pose, const Pose3& transform, const Point3& point) {
+        return factor.evaluateError(pose, transform, point);
+      },
       pose, body_P_sensor, point);
 
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));

--- a/gtsam_unstable/slam/tests/testProjectionFactorPPPC.cpp
+++ b/gtsam_unstable/slam/tests/testProjectionFactorPPPC.cpp
@@ -136,15 +136,11 @@ TEST( ProjectionFactorPPPC, Jacobian ) {
 
   // Verify H2 and H4 with numerical derivatives
   Matrix H2Expected = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestProjectionFactor::evaluateError, &factor, pose,
-                std::placeholders::_1, point, *K1, boost::none, boost::none,
-                boost::none, boost::none),
+      [&factor, &point, &pose](const Pose3& pose_arg) { return factor.evaluateError(pose, pose_arg, point, *K1); },
       Pose3());
 
   Matrix H4Expected = numericalDerivative11<Vector, Cal3_S2>(
-      std::bind(&TestProjectionFactor::evaluateError, &factor, pose, Pose3(),
-                point, std::placeholders::_1, boost::none, boost::none,
-                boost::none, boost::none),
+      [&factor, &point, &pose](const Cal3_S2& K_arg) { return factor.evaluateError(pose, Pose3(), point, K_arg); },
       *K1);
 
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
@@ -176,12 +172,16 @@ TEST( ProjectionFactorPPPC, JacobianWithTransform ) {
 
   // Verify H2 and H4 with numerical derivatives
   Matrix H2Expected = numericalDerivative11<Vector, Pose3>(
-      std::bind(&TestProjectionFactor::evaluateError, &factor, pose, std::placeholders::_1, point,
-          *K1, boost::none, boost::none, boost::none, boost::none), body_P_sensor);
+      [&factor, &pose, &point](const Pose3& body_P_sensor) {
+        return factor.evaluateError(pose, body_P_sensor, point, *K1);
+      },
+      body_P_sensor);
 
   Matrix H4Expected = numericalDerivative11<Vector, Cal3_S2>(
-      std::bind(&TestProjectionFactor::evaluateError, &factor, pose, body_P_sensor, point,
-          std::placeholders::_1, boost::none, boost::none, boost::none, boost::none), *K1);
+      [&factor, &pose, &body_P_sensor, &point](const Cal3_S2& K) {
+        return factor.evaluateError(pose, body_P_sensor, point, K);
+      },
+      *K1);
 
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
   CHECK(assert_equal(H4Expected, H4Actual, 1e-5));

--- a/gtsam_unstable/slam/tests/testProjectionFactorRollingShutter.cpp
+++ b/gtsam_unstable/slam/tests/testProjectionFactorRollingShutter.cpp
@@ -230,30 +230,15 @@ TEST(ProjectionFactorRollingShutter, Jacobian) {
   Matrix H1Actual, H2Actual, H3Actual;
   factor.evaluateError(pose1, pose2, point, H1Actual, H2Actual, H3Actual);
 
+  auto f = [&factor](const Pose3& p1, const Pose3& p2, const Point3& p3) {
+	  return factor.evaluateError(p1, p2, p3); 
+  };
   // Expected Jacobians via numerical derivatives
-  Matrix H1Expected = numericalDerivative31<Vector, Pose3, Pose3, Point3>(
-      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
-                    std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, boost::none, boost::none,
-                    boost::none)),
-      pose1, pose2, point);
+  Matrix H1Expected = numericalDerivative31<Vector, Pose3, Pose3, Point3>(f, pose1, pose2, point);
 
-  Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
-      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
-                    std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, boost::none, boost::none,
-                    boost::none)),
-      pose1, pose2, point);
+  Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(f, pose1, pose2, point);
 
-  Matrix H3Expected = numericalDerivative33<Vector, Pose3, Pose3, Point3>(
-      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
-                    std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, boost::none, boost::none,
-                    boost::none)),
-      pose1, pose2, point);
+  Matrix H3Expected = numericalDerivative33<Vector, Pose3, Pose3, Point3>(f, pose1, pose2, point);
 
   CHECK(assert_equal(H1Expected, H1Actual, 1e-5));
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));
@@ -280,30 +265,15 @@ TEST(ProjectionFactorRollingShutter, JacobianWithTransform) {
   Matrix H1Actual, H2Actual, H3Actual;
   factor.evaluateError(pose1, pose2, point, H1Actual, H2Actual, H3Actual);
 
+  auto f = [&factor](const Pose3& p1, const Pose3& p2, const Point3& p3) {
+	  return factor.evaluateError(p1, p2, p3); 
+  };
   // Expected Jacobians via numerical derivatives
-  Matrix H1Expected = numericalDerivative31<Vector, Pose3, Pose3, Point3>(
-      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
-                    std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, boost::none, boost::none,
-                    boost::none)),
-      pose1, pose2, point);
+  Matrix H1Expected = numericalDerivative31<Vector, Pose3, Pose3, Point3>(f, pose1, pose2, point);
 
-  Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(
-      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
-                    std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, boost::none, boost::none,
-                    boost::none)),
-      pose1, pose2, point);
+  Matrix H2Expected = numericalDerivative32<Vector, Pose3, Pose3, Point3>(f, pose1, pose2, point);
 
-  Matrix H3Expected = numericalDerivative33<Vector, Pose3, Pose3, Point3>(
-      std::function<Vector(const Pose3&, const Pose3&, const Point3&)>(
-          std::bind(&ProjectionFactorRollingShutter::evaluateError, &factor,
-                    std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, boost::none, boost::none,
-                    boost::none)),
-      pose1, pose2, point);
+  Matrix H3Expected = numericalDerivative33<Vector, Pose3, Pose3, Point3>(f, pose1, pose2, point);
 
   CHECK(assert_equal(H1Expected, H1Actual, 1e-5));
   CHECK(assert_equal(H2Expected, H2Actual, 1e-5));

--- a/gtsam_unstable/slam/tests/testTSAMFactors.cpp
+++ b/gtsam_unstable/slam/tests/testTSAMFactors.cpp
@@ -20,6 +20,7 @@
 #include <gtsam/base/numericalDerivative.h>
 
 #include <CppUnitLite/TestHarness.h>
+#include "gtsam/geometry/Point2.h"
 
 using namespace std::placeholders;
 using namespace std;
@@ -46,12 +47,11 @@ TEST( DeltaFactor, all ) {
 
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected;
+
   H1Expected = numericalDerivative11<Vector2, Pose2>(
-      std::bind(&DeltaFactor::evaluateError, &factor, std::placeholders::_1, point, boost::none,
-          boost::none), pose);
+      [&factor, &point](const Pose2& pose) { return factor.evaluateError(pose, point); }, pose);
   H2Expected = numericalDerivative11<Vector2, Point2>(
-      std::bind(&DeltaFactor::evaluateError, &factor, pose, std::placeholders::_1, boost::none,
-          boost::none), point);
+      [&factor, &pose](const Point2& point) { return factor.evaluateError(pose, point); }, point);
 
   // Verify the Jacobians are correct
   EXPECT(assert_equal(H1Expected, H1Actual, 1e-9));
@@ -81,17 +81,25 @@ TEST( DeltaFactorBase, all ) {
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected, H3Expected, H4Expected;
   H1Expected = numericalDerivative11<Vector2, Pose2>(
-      std::bind(&DeltaFactorBase::evaluateError, &factor, std::placeholders::_1, pose, base2,
-          point, boost::none, boost::none, boost::none, boost::none), base1);
+      [&factor, &pose, &base2, &point](const Pose2& pose_arg) {
+        return factor.evaluateError(pose_arg, pose, base2, point);
+      },
+      base1);
   H2Expected = numericalDerivative11<Vector2, Pose2>(
-      std::bind(&DeltaFactorBase::evaluateError, &factor, base1, std::placeholders::_1, base2,
-          point, boost::none, boost::none, boost::none, boost::none), pose);
+      [&factor, &point, &base1, &base2](const Pose2& pose_arg) {
+        return factor.evaluateError(base1, pose_arg, base2, point);
+      },
+      pose);
   H3Expected = numericalDerivative11<Vector2, Pose2>(
-      std::bind(&DeltaFactorBase::evaluateError, &factor, base1, pose, std::placeholders::_1,
-          point, boost::none, boost::none, boost::none, boost::none), base2);
+      [&factor, &pose, &base1, &point](const Pose2& pose_arg) {
+        return factor.evaluateError(base1, pose, pose_arg, point);
+      },
+      base2);
   H4Expected = numericalDerivative11<Vector2, Point2>(
-      std::bind(&DeltaFactorBase::evaluateError, &factor, base1, pose, base2,
-          std::placeholders::_1, boost::none, boost::none, boost::none, boost::none), point);
+      [&factor, &pose, &base1, &base2](const Point2& point_arg) {
+        return factor.evaluateError(base1, pose, base2, point_arg);
+      },
+      point);
 
   // Verify the Jacobians are correct
   EXPECT(assert_equal(H1Expected, H1Actual, 1e-9));
@@ -121,18 +129,26 @@ TEST( OdometryFactorBase, all ) {
 
   // Use numerical derivatives to calculate the Jacobians
   Matrix H1Expected, H2Expected, H3Expected, H4Expected;
+  // using lambdas to replace bind
   H1Expected = numericalDerivative11<Vector3, Pose2>(
-      std::bind(&OdometryFactorBase::evaluateError, &factor, std::placeholders::_1, pose1, base2,
-          pose2, boost::none, boost::none, boost::none, boost::none), base1);
+      [&factor, &pose1, &pose2, &base2](const Pose2& pose_arg) {
+        return factor.evaluateError(pose_arg, pose1, base2, pose2);
+      },
+      base1);
   H2Expected = numericalDerivative11<Vector3, Pose2>(
-      std::bind(&OdometryFactorBase::evaluateError, &factor, base1, std::placeholders::_1, base2,
-          pose2, boost::none, boost::none, boost::none, boost::none), pose1);
+      [&factor, &pose2, &base1, &base2](const Pose2& pose_arg) {
+        return factor.evaluateError(base1, pose_arg, base2, pose2);
+      },
+      pose1);
   H3Expected = numericalDerivative11<Vector3, Pose2>(
-      std::bind(&OdometryFactorBase::evaluateError, &factor, base1, pose1, std::placeholders::_1,
-          pose2, boost::none, boost::none, boost::none, boost::none), base2);
+      [&factor, &pose1, &base1, &pose2](const Pose2& pose_arg) {
+        return factor.evaluateError(base1, pose1, pose_arg, pose2);
+      },
+      base2);
   H4Expected = numericalDerivative11<Vector3, Pose2>(
-      std::bind(&OdometryFactorBase::evaluateError, &factor, base1, pose1,
-          base2, std::placeholders::_1, boost::none, boost::none, boost::none, boost::none),
+      [&factor, &pose1, &base1, &base2](const Pose2& pose_arg) {
+        return factor.evaluateError(base1, pose1, base2, pose_arg);
+      },
       pose2);
 
   // Verify the Jacobians are correct

--- a/tests/simulated2D.h
+++ b/tests/simulated2D.h
@@ -133,6 +133,7 @@ namespace simulated2D {
     typedef boost::shared_ptr<GenericPrior<VALUE> > shared_ptr;
     typedef VALUE Pose; ///< shortcut to Pose type
 	
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
     Pose measured_; ///< prior mean
@@ -179,6 +180,7 @@ namespace simulated2D {
     typedef boost::shared_ptr<GenericOdometry<VALUE> > shared_ptr;
     typedef VALUE Pose; ///< shortcut to Pose type
 
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
     Pose measured_; ///< odometry measurement
@@ -227,6 +229,7 @@ namespace simulated2D {
     typedef POSE Pose; ///< shortcut to Pose type
     typedef LANDMARK Landmark; ///< shortcut to Landmark type
 
+    // Provide access to the Matrix& version of evaluateError:
     using Base::evaluateError;
 
     Landmark measured_; ///< Measurement

--- a/tests/simulated2D.h
+++ b/tests/simulated2D.h
@@ -139,7 +139,7 @@ namespace simulated2D {
     }
 
     /// Return error and optional derivative
-    Vector evaluateError(const Pose& x, boost::optional<Matrix&> H = boost::none) const override {
+    Vector evaluateError(const Pose& x, OptionalMatrixType H = OptionalNone) const override {
       return (prior(x, H) - measured_);
     }
 
@@ -184,8 +184,8 @@ namespace simulated2D {
 
     /// Evaluate error and optionally return derivatives
     Vector evaluateError(const Pose& x1, const Pose& x2,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none) const override {
+        OptionalMatrixType H1 = OptionalNone,
+        OptionalMatrixType H2 = OptionalNone) const override {
       return (odo(x1, x2, H1, H2) - measured_);
     }
 
@@ -231,8 +231,8 @@ namespace simulated2D {
 
     /// Evaluate error and optionally return derivatives
     Vector evaluateError(const Pose& x1, const Landmark& x2,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none) const override {
+        OptionalMatrixType H1 = OptionalNone,
+        OptionalMatrixType H2 = OptionalNone) const override {
       return (mea(x1, x2, H1, H2) - measured_);
     }
 

--- a/tests/simulated2D.h
+++ b/tests/simulated2D.h
@@ -144,7 +144,7 @@ namespace simulated2D {
 
     /// Return error and optional derivative
     Vector evaluateError(const Pose& x, OptionalMatrixType H) const override {
-      return (prior(x, H) - measured_);
+      return (simulated2D::prior(x, H) - measured_);
     }
 
     ~GenericPrior() override {}

--- a/tests/simulated2DConstraints.h
+++ b/tests/simulated2DConstraints.h
@@ -25,6 +25,7 @@
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/BoundingConstraint.h>
 #include <tests/simulated2D.h>
+#include "gtsam/nonlinear/NonlinearFactor.h"
 
 // \namespace
 
@@ -87,8 +88,8 @@ namespace simulated2D {
        * @param x is the estimate of the constrained variable being evaluated
        * @param H is an optional Jacobian, linearized at x
        */
-      double value(const Point& x, boost::optional<Matrix&> H =
-          boost::none) const override {
+      double value(const Point& x, OptionalMatrixType H =
+          OptionalNone) const override {
         if (H) {
           Matrix D = Matrix::Zero(1, traits<Point>::GetDimension(x));
           D(0, IDX) = 1.0;
@@ -151,8 +152,8 @@ namespace simulated2D {
        * @return the distance between the variables
        */
       double value(const Point& x1, const Point& x2,
-          boost::optional<Matrix&> H1 = boost::none,
-          boost::optional<Matrix&> H2 = boost::none) const override {
+          OptionalMatrixType H1 = OptionalNone,
+          OptionalMatrixType H2 = OptionalNone) const override {
         if (H1) *H1 = numericalDerivative21(range_trait<Point,Point>, x1, x2, 1e-5);
         if (H1) *H2 = numericalDerivative22(range_trait<Point,Point>, x1, x2, 1e-5);
         return range_trait(x1, x2);
@@ -201,8 +202,8 @@ namespace simulated2D {
        * @return the distance between the variables
        */
       double value(const Pose& x1, const Point& x2,
-          boost::optional<Matrix&> H1 = boost::none,
-          boost::optional<Matrix&> H2 = boost::none) const override {
+          OptionalMatrixType H1 = OptionalNone,
+          OptionalMatrixType H2 = OptionalNone) const override {
         if (H1) *H1 = numericalDerivative21(range_trait<Pose,Point>, x1, x2, 1e-5);
         if (H1) *H2 = numericalDerivative22(range_trait<Pose,Point>, x1, x2, 1e-5);
         return range_trait(x1, x2);

--- a/tests/simulated2DOriented.h
+++ b/tests/simulated2DOriented.h
@@ -106,7 +106,9 @@ namespace simulated2DOriented {
     Pose2 measured_;   ///< Between measurement for odometry factor
 
     typedef GenericOdometry<VALUE> This;
-	using NoiseModelFactor2<VALUE, VALUE>::evaluateError;
+
+    // Provide access to the Matrix& version of evaluateError:
+	  using NoiseModelFactor2<VALUE, VALUE>::evaluateError;
 
     /**
      * Creates an odometry factor between two poses

--- a/tests/simulated2DOriented.h
+++ b/tests/simulated2DOriented.h
@@ -22,6 +22,7 @@
 #include <gtsam/nonlinear/Values.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include "gtsam/base/OptionalJacobian.h"
 
 // \namespace
 namespace simulated2DOriented {
@@ -62,7 +63,7 @@ namespace simulated2DOriented {
   }
 
   /// Prior on a single pose, optional derivative version
-  Pose2 prior(const Pose2& x, boost::optional<Matrix&> H = boost::none) {
+  Pose2 prior(const Pose2& x, OptionalJacobian<3,3> H = OptionalNone) {
     if (H) *H = I_3x3;
     return x;
   }
@@ -73,8 +74,8 @@ namespace simulated2DOriented {
   }
 
   /// odometry between two poses, optional derivative version
-  Pose2 odo(const Pose2& x1, const Pose2& x2, boost::optional<Matrix&> H1 =
-      boost::none, boost::optional<Matrix&> H2 = boost::none) {
+  Pose2 odo(const Pose2& x1, const Pose2& x2, OptionalJacobian<3,3> H1 =
+      OptionalNone, OptionalJacobian<3,3> H2 = OptionalNone) {
     return x1.between(x2, H1, H2);
   }
 
@@ -105,6 +106,7 @@ namespace simulated2DOriented {
     Pose2 measured_;   ///< Between measurement for odometry factor
 
     typedef GenericOdometry<VALUE> This;
+	using NoiseModelFactor2<VALUE, VALUE>::evaluateError;
 
     /**
      * Creates an odometry factor between two poses
@@ -118,8 +120,7 @@ namespace simulated2DOriented {
 
     /// Evaluate error and optionally derivative
     Vector evaluateError(const VALUE& x1, const VALUE& x2,
-        OptionalMatrixType H1 = OptionalNone,
-        OptionalMatrixType H2 = OptionalNone) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2) const override {
       return measured_.localCoordinates(odo(x1, x2, H1, H2));
     }
 

--- a/tests/simulated2DOriented.h
+++ b/tests/simulated2DOriented.h
@@ -108,7 +108,7 @@ namespace simulated2DOriented {
     typedef GenericOdometry<VALUE> This;
 
     // Provide access to the Matrix& version of evaluateError:
-	  using NoiseModelFactor2<VALUE, VALUE>::evaluateError;
+    using NoiseModelFactor2<VALUE, VALUE>::evaluateError;
 
     /**
      * Creates an odometry factor between two poses

--- a/tests/simulated2DOriented.h
+++ b/tests/simulated2DOriented.h
@@ -90,8 +90,8 @@ namespace simulated2DOriented {
     }
 
     /// Evaluate error and optionally derivative
-    Vector evaluateError(const Pose2& x, boost::optional<Matrix&> H =
-        boost::none) const {
+    Vector evaluateError(const Pose2& x, OptionalMatrixType H =
+        OptionalNone) const {
       return measured_.localCoordinates(prior(x, H));
     }
 
@@ -118,8 +118,8 @@ namespace simulated2DOriented {
 
     /// Evaluate error and optionally derivative
     Vector evaluateError(const VALUE& x1, const VALUE& x2,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none) const override {
+        OptionalMatrixType H1 = OptionalNone,
+        OptionalMatrixType H2 = OptionalNone) const override {
       return measured_.localCoordinates(odo(x1, x2, H1, H2));
     }
 

--- a/tests/simulated3D.h
+++ b/tests/simulated3D.h
@@ -92,7 +92,7 @@ struct PointPrior3D: public NoiseModelFactor1<Point3> {
    * @return Vector error between prior value and x (Dimension: 3)
    */
   Vector evaluateError(const Point3& x, OptionalMatrixType H) const override {
-    return prior(x, H) - measured_;
+    return simulated3D::prior(x, H) - measured_;
   }
 };
 

--- a/tests/simulated3D.h
+++ b/tests/simulated3D.h
@@ -23,6 +23,7 @@
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
+#include "gtsam/base/OptionalJacobian.h"
 
 // \namespace
 
@@ -38,7 +39,7 @@ namespace simulated3D {
 /**
  * Prior on a single pose
  */
-Point3 prior(const Point3& x, boost::optional<Matrix&> H = boost::none) {
+Point3 prior(const Point3& x, OptionalJacobian<3,3> H = OptionalNone) {
   if (H) *H = I_3x3;
   return x;
 }
@@ -47,8 +48,8 @@ Point3 prior(const Point3& x, boost::optional<Matrix&> H = boost::none) {
  * odometry between two poses
  */
 Point3 odo(const Point3& x1, const Point3& x2,
-    boost::optional<Matrix&> H1 = boost::none,
-    boost::optional<Matrix&> H2 = boost::none) {
+    OptionalJacobian<3,3> H1 = OptionalNone,
+    OptionalJacobian<3,3> H2 = OptionalNone) {
   if (H1) *H1 = -1 * I_3x3;
   if (H2) *H2 = I_3x3;
   return x2 - x1;
@@ -58,8 +59,8 @@ Point3 odo(const Point3& x1, const Point3& x2,
  *  measurement between landmark and pose
  */
 Point3 mea(const Point3& x, const Point3& l,
-    boost::optional<Matrix&> H1 = boost::none,
-    boost::optional<Matrix&> H2 = boost::none) {
+    OptionalJacobian<3,3> H1 = OptionalNone,
+    OptionalJacobian<3,3> H2 = OptionalNone) {
   if (H1) *H1 = -1 * I_3x3;
   if (H2) *H2 = I_3x3;
   return l - x;
@@ -68,7 +69,8 @@ Point3 mea(const Point3& x, const Point3& l,
 /**
  * A prior factor on a single linear robot pose
  */
-struct PointPrior3D: public NoiseModelFactorN<Point3> {
+struct PointPrior3D: public NoiseModelFactor1<Point3> {
+  using NoiseModelFactor1<Point3>::evaluateError;
 
   Point3 measured_; ///< The prior pose value for the variable attached to this factor
 
@@ -89,8 +91,7 @@ struct PointPrior3D: public NoiseModelFactorN<Point3> {
    * @param H is an optional Jacobian matrix (Dimension: 3x3)
    * @return Vector error between prior value and x (Dimension: 3)
    */
-  Vector evaluateError(const Point3& x, OptionalMatrixType H =
-      OptionalNone) const override {
+  Vector evaluateError(const Point3& x, OptionalMatrixType H) const override {
     return prior(x, H) - measured_;
   }
 };
@@ -98,7 +99,12 @@ struct PointPrior3D: public NoiseModelFactorN<Point3> {
 /**
  * Models a linear 3D measurement between 3D points
  */
+<<<<<<< HEAD
 struct Simulated3DMeasurement: public NoiseModelFactorN<Point3, Point3> {
+=======
+struct Simulated3DMeasurement: public NoiseModelFactor2<Point3, Point3> {
+  using NoiseModelFactor2<Point3, Point3>::evaluateError;
+>>>>>>> 7b3c40e92 (everything compiles but tests fail in no boost mode)
 
   Point3 measured_; ///< Linear displacement between a pose and landmark
 
@@ -121,7 +127,7 @@ struct Simulated3DMeasurement: public NoiseModelFactorN<Point3, Point3> {
    * @return vector error between measurement and prediction (Dimension: 3)
    */
   Vector evaluateError(const Point3& x1, const Point3& x2,
-      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
     return mea(x1, x2, H1, H2) - measured_;
   }
 };

--- a/tests/simulated3D.h
+++ b/tests/simulated3D.h
@@ -89,8 +89,8 @@ struct PointPrior3D: public NoiseModelFactorN<Point3> {
    * @param H is an optional Jacobian matrix (Dimension: 3x3)
    * @return Vector error between prior value and x (Dimension: 3)
    */
-  Vector evaluateError(const Point3& x, boost::optional<Matrix&> H =
-      boost::none) const override {
+  Vector evaluateError(const Point3& x, OptionalMatrixType H =
+      OptionalNone) const override {
     return prior(x, H) - measured_;
   }
 };
@@ -121,7 +121,7 @@ struct Simulated3DMeasurement: public NoiseModelFactorN<Point3, Point3> {
    * @return vector error between measurement and prediction (Dimension: 3)
    */
   Vector evaluateError(const Point3& x1, const Point3& x2,
-      boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 = boost::none) const override {
+      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 = OptionalNone) const override {
     return mea(x1, x2, H1, H2) - measured_;
   }
 };

--- a/tests/simulated3D.h
+++ b/tests/simulated3D.h
@@ -99,12 +99,8 @@ struct PointPrior3D: public NoiseModelFactor1<Point3> {
 /**
  * Models a linear 3D measurement between 3D points
  */
-<<<<<<< HEAD
 struct Simulated3DMeasurement: public NoiseModelFactorN<Point3, Point3> {
-=======
-struct Simulated3DMeasurement: public NoiseModelFactor2<Point3, Point3> {
   using NoiseModelFactor2<Point3, Point3>::evaluateError;
->>>>>>> 7b3c40e92 (everything compiles but tests fail in no boost mode)
 
   Point3 measured_; ///< Linear displacement between a pose and landmark
 

--- a/tests/smallExample.h
+++ b/tests/smallExample.h
@@ -329,13 +329,14 @@ inline Matrix H(const Point2& v) {
 
 struct UnaryFactor: public gtsam::NoiseModelFactorN<Point2> {
 
+  using gtsam::NoiseModelFactor1<Point2>::evaluateError;
   Point2 z_;
 
   UnaryFactor(const Point2& z, const SharedNoiseModel& model, Key key) :
     gtsam::NoiseModelFactorN<Point2>(model, key), z_(z) {
   }
 
-  Vector evaluateError(const Point2& x, OptionalMatrixType A = OptionalNone) const override {
+  Vector evaluateError(const Point2& x, OptionalMatrixType A) const override {
     if (A) *A = H(x);
     return (h(x) - z_);
   }

--- a/tests/smallExample.h
+++ b/tests/smallExample.h
@@ -335,7 +335,7 @@ struct UnaryFactor: public gtsam::NoiseModelFactorN<Point2> {
     gtsam::NoiseModelFactorN<Point2>(model, key), z_(z) {
   }
 
-  Vector evaluateError(const Point2& x, boost::optional<Matrix&> A = boost::none) const override {
+  Vector evaluateError(const Point2& x, OptionalMatrixType A = OptionalNone) const override {
     if (A) *A = H(x);
     return (h(x) - z_);
   }

--- a/tests/smallExample.h
+++ b/tests/smallExample.h
@@ -329,7 +329,9 @@ inline Matrix H(const Point2& v) {
 
 struct UnaryFactor: public gtsam::NoiseModelFactorN<Point2> {
 
+  // Provide access to the Matrix& version of evaluateError:
   using gtsam::NoiseModelFactor1<Point2>::evaluateError;
+
   Point2 z_;
 
   UnaryFactor(const Point2& z, const SharedNoiseModel& model, Key key) :

--- a/tests/testExtendedKalmanFilter.cpp
+++ b/tests/testExtendedKalmanFilter.cpp
@@ -101,6 +101,8 @@ protected:
   Matrix Q_invsqrt_;
 
 public:
+  using Base::evaluateError;
+
   NonlinearMotionModel(){}
 
   NonlinearMotionModel(const Symbol& TestKey1, const Symbol& TestKey2) :
@@ -213,8 +215,7 @@ public:
 
   /** vector of errors */
   Vector evaluateError(const Point2& p1, const Point2& p2,
-      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 =
-          OptionalNone) const override {
+      OptionalMatrixType H1, OptionalMatrixType H2) const override {
 
     // error = p2 - f(p1)
     // H1 = d error / d p1 = -d f/ d p1 = -F
@@ -245,6 +246,7 @@ protected:
   Matrix R_invsqrt_; /** The inv sqrt of the measurement error covariance */
 
 public:
+  using Base::evaluateError;
   NonlinearMeasurementModel(){}
 
   NonlinearMeasurementModel(const Symbol& TestKey, Vector z) :
@@ -339,7 +341,7 @@ public:
   }
 
   /** vector of errors */
-  Vector evaluateError(const Point2& p, OptionalMatrixType H1 = OptionalNone) const override {
+  Vector evaluateError(const Point2& p, OptionalMatrixType H1) const override {
     // error = z - h(p)
     // H = d error / d p = -d h/ d p = -H
     Vector z_hat = h(p);

--- a/tests/testExtendedKalmanFilter.cpp
+++ b/tests/testExtendedKalmanFilter.cpp
@@ -101,6 +101,7 @@ protected:
   Matrix Q_invsqrt_;
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   NonlinearMotionModel(){}
@@ -246,6 +247,7 @@ protected:
   Matrix R_invsqrt_; /** The inv sqrt of the measurement error covariance */
 
 public:
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   NonlinearMeasurementModel(){}
 

--- a/tests/testExtendedKalmanFilter.cpp
+++ b/tests/testExtendedKalmanFilter.cpp
@@ -101,6 +101,7 @@ protected:
   Matrix Q_invsqrt_;
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -247,6 +248,7 @@ protected:
   Matrix R_invsqrt_; /** The inv sqrt of the measurement error covariance */
 
 public:
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/tests/testExtendedKalmanFilter.cpp
+++ b/tests/testExtendedKalmanFilter.cpp
@@ -249,6 +249,7 @@ protected:
 public:
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   NonlinearMeasurementModel(){}
 
   NonlinearMeasurementModel(const Symbol& TestKey, Vector z) :

--- a/tests/testExtendedKalmanFilter.cpp
+++ b/tests/testExtendedKalmanFilter.cpp
@@ -213,8 +213,8 @@ public:
 
   /** vector of errors */
   Vector evaluateError(const Point2& p1, const Point2& p2,
-      boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 =
-          boost::none) const override {
+      OptionalMatrixType H1 = OptionalNone, OptionalMatrixType H2 =
+          OptionalNone) const override {
 
     // error = p2 - f(p1)
     // H1 = d error / d p1 = -d f/ d p1 = -F
@@ -339,7 +339,7 @@ public:
   }
 
   /** vector of errors */
-  Vector evaluateError(const Point2& p, boost::optional<Matrix&> H1 = boost::none) const override {
+  Vector evaluateError(const Point2& p, OptionalMatrixType H1 = OptionalNone) const override {
     // error = z - h(p)
     // H = d error / d p = -d h/ d p = -H
     Vector z_hat = h(p);

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -42,7 +42,7 @@ SharedDiagonal odoNoise = noiseModel::Diagonal::Sigmas((Vector(3) << 0.1, 0.1, M
 SharedDiagonal brNoise = noiseModel::Diagonal::Sigmas((Vector(2) << M_PI/100.0, 0.1).finished());
 
 ISAM2 createSlamlikeISAM2(
-    boost::optional<Values&> init_values = boost::none,
+    Values* init_values = nullptr,
     boost::optional<NonlinearFactorGraph&> full_graph = boost::none,
     const ISAM2Params& params = ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0,
                                             0, false, true,
@@ -288,7 +288,7 @@ TEST(ISAM2, simple)
     // These variables will be reused and accumulate factors and values
     Values fullinit;
     NonlinearFactorGraph fullgraph;
-    ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false), i);
+    ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false), i);
 
     // Compare solutions
     EXPECT(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -301,7 +301,7 @@ TEST(ISAM2, slamlike_solution_gaussnewton)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -313,7 +313,7 @@ TEST(ISAM2, slamlike_solution_dogleg)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -325,7 +325,7 @@ TEST(ISAM2, slamlike_solution_gaussnewton_qr)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false, false, ISAM2Params::QR));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false, false, ISAM2Params::QR));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -337,7 +337,7 @@ TEST(ISAM2, slamlike_solution_dogleg_qr)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false, false, ISAM2Params::QR));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false, false, ISAM2Params::QR));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -386,7 +386,7 @@ TEST(ISAM2, removeFactors)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
 
   // Remove the 2nd measurement on landmark 0 (Key 100)
   FactorIndices toRemove;
@@ -406,7 +406,7 @@ TEST(ISAM2, removeVariables)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
 
   // Remove the measurement on landmark 0 (Key 100)
   FactorIndices toRemove;
@@ -431,7 +431,7 @@ TEST(ISAM2, swapFactors)
 
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph);
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph);
 
   // Remove the measurement on landmark 0 and replace with a different one
   {
@@ -610,7 +610,7 @@ TEST(ISAM2, slamlike_solution_partial_relinearization_check)
   NonlinearFactorGraph fullgraph;
   ISAM2Params params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false);
   params.enablePartialRelinearizationCheck = true;
-  ISAM2 isam = createSlamlikeISAM2(fullinit, fullgraph, params);
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, params);
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));

--- a/tests/testGaussianISAM2.cpp
+++ b/tests/testGaussianISAM2.cpp
@@ -43,7 +43,7 @@ SharedDiagonal brNoise = noiseModel::Diagonal::Sigmas((Vector(2) << M_PI/100.0, 
 
 ISAM2 createSlamlikeISAM2(
     Values* init_values = nullptr,
-    boost::optional<NonlinearFactorGraph&> full_graph = boost::none,
+    NonlinearFactorGraph* full_graph = nullptr,
     const ISAM2Params& params = ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0,
                                             0, false, true,
                                             ISAM2Params::CHOLESKY, true,
@@ -288,7 +288,7 @@ TEST(ISAM2, simple)
     // These variables will be reused and accumulate factors and values
     Values fullinit;
     NonlinearFactorGraph fullgraph;
-    ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false), i);
+    ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false), i);
 
     // Compare solutions
     EXPECT(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -301,7 +301,7 @@ TEST(ISAM2, slamlike_solution_gaussnewton)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -313,7 +313,7 @@ TEST(ISAM2, slamlike_solution_dogleg)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -325,7 +325,7 @@ TEST(ISAM2, slamlike_solution_gaussnewton_qr)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false, false, ISAM2Params::QR));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false, false, ISAM2Params::QR));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -337,7 +337,7 @@ TEST(ISAM2, slamlike_solution_dogleg_qr)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false, false, ISAM2Params::QR));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, ISAM2Params(ISAM2DoglegParams(1.0), 0.0, 0, false, false, ISAM2Params::QR));
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));
@@ -386,7 +386,7 @@ TEST(ISAM2, removeFactors)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
 
   // Remove the 2nd measurement on landmark 0 (Key 100)
   FactorIndices toRemove;
@@ -406,7 +406,7 @@ TEST(ISAM2, removeVariables)
   // These variables will be reused and accumulate factors and values
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, ISAM2Params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false));
 
   // Remove the measurement on landmark 0 (Key 100)
   FactorIndices toRemove;
@@ -431,7 +431,7 @@ TEST(ISAM2, swapFactors)
 
   Values fullinit;
   NonlinearFactorGraph fullgraph;
-  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph);
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph);
 
   // Remove the measurement on landmark 0 and replace with a different one
   {
@@ -610,7 +610,7 @@ TEST(ISAM2, slamlike_solution_partial_relinearization_check)
   NonlinearFactorGraph fullgraph;
   ISAM2Params params(ISAM2GaussNewtonParams(0.001), 0.0, 0, false);
   params.enablePartialRelinearizationCheck = true;
-  ISAM2 isam = createSlamlikeISAM2(&fullinit, fullgraph, params);
+  ISAM2 isam = createSlamlikeISAM2(&fullinit, &fullgraph, params);
 
   // Compare solutions
   CHECK(isam_check(fullgraph, fullinit, isam, *this, result_));

--- a/tests/testNonlinearFactor.cpp
+++ b/tests/testNonlinearFactor.cpp
@@ -340,8 +340,7 @@ class TestFactor1 : public NoiseModelFactor1<double> {
   TestFactor1() : Base(noiseModel::Diagonal::Sigmas(Vector1(2.0)), L(1)) {}
   using Base::NoiseModelFactor1;  // inherit constructors
 
-  Vector evaluateError(const double& x1, boost::optional<Matrix&> H1 =
-                                             boost::none) const override {
+  Vector evaluateError(const double& x1, OptionalMatrixType H1 = OptionalNone) const override {
     if (H1) *H1 = (Matrix(1, 1) << 1.0).finished();
     return (Vector(1) << x1).finished();
   }
@@ -394,10 +393,10 @@ class TestFactor4 : public NoiseModelFactor4<double, double, double, double> {
 
   Vector
     evaluateError(const double& x1, const double& x2, const double& x3, const double& x4,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none,
-        boost::optional<Matrix&> H3 = boost::none,
-        boost::optional<Matrix&> H4 = boost::none) const override {
+        OptionalMatrixType H1 = OptionalNone,
+        OptionalMatrixType H2 = OptionalNone,
+        OptionalMatrixType H3 = OptionalNone,
+        OptionalMatrixType H4 = OptionalNone) const override {
     if(H1) {
       *H1 = (Matrix(1, 1) << 1.0).finished();
       *H2 = (Matrix(1, 1) << 2.0).finished();
@@ -484,11 +483,11 @@ public:
 
   Vector
     evaluateError(const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none,
-        boost::optional<Matrix&> H3 = boost::none,
-        boost::optional<Matrix&> H4 = boost::none,
-        boost::optional<Matrix&> H5 = boost::none) const override {
+        OptionalMatrixType H1 = OptionalNone,
+        OptionalMatrixType H2 = OptionalNone,
+        OptionalMatrixType H3 = OptionalNone,
+        OptionalMatrixType H4 = OptionalNone,
+        OptionalMatrixType H5 = OptionalNone) const override {
     if(H1) {
       *H1 = (Matrix(1, 1) << 1.0).finished();
       *H2 = (Matrix(1, 1) << 2.0).finished();
@@ -534,12 +533,12 @@ public:
 
   Vector
     evaluateError(const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none,
-        boost::optional<Matrix&> H3 = boost::none,
-        boost::optional<Matrix&> H4 = boost::none,
-        boost::optional<Matrix&> H5 = boost::none,
-        boost::optional<Matrix&> H6 = boost::none) const override {
+        OptionalMatrixType H1 = OptionalNone,
+        OptionalMatrixType H2 = OptionalNone,
+        OptionalMatrixType H3 = OptionalNone,
+        OptionalMatrixType H4 = OptionalNone,
+        OptionalMatrixType H5 = OptionalNone,
+        OptionalMatrixType H6 = OptionalNone) const override {
     if(H1) {
       *H1 = (Matrix(1, 1) << 1.0).finished();
       *H2 = (Matrix(1, 1) << 2.0).finished();
@@ -594,10 +593,10 @@ public:
 
   Vector
     evaluateError(const double& x1, const double& x2, const double& x3, const double& x4,
-        boost::optional<Matrix&> H1 = boost::none,
-        boost::optional<Matrix&> H2 = boost::none,
-        boost::optional<Matrix&> H3 = boost::none,
-        boost::optional<Matrix&> H4 = boost::none) const override {
+        OptionalMatrixType H1 = OptionalNone,
+        OptionalMatrixType H2 = OptionalNone,
+        OptionalMatrixType H3 = OptionalNone,
+        OptionalMatrixType H4 = OptionalNone) const override {
     if (H1) *H1 = (Matrix(1, 1) << 1.0).finished();
     if (H2) *H2 = (Matrix(1, 1) << 2.0).finished();
     if (H3) *H3 = (Matrix(1, 1) << 3.0).finished();

--- a/tests/testNonlinearFactor.cpp
+++ b/tests/testNonlinearFactor.cpp
@@ -337,10 +337,11 @@ class TestFactor1 : public NoiseModelFactor1<double> {
 
  public:
   typedef NoiseModelFactor1<double> Base;
+  using Base::evaluateError;
   TestFactor1() : Base(noiseModel::Diagonal::Sigmas(Vector1(2.0)), L(1)) {}
   using Base::NoiseModelFactor1;  // inherit constructors
 
-  Vector evaluateError(const double& x1, OptionalMatrixType H1 = OptionalNone) const override {
+  Vector evaluateError(const double& x1, OptionalMatrixType H1) const override {
     if (H1) *H1 = (Matrix(1, 1) << 1.0).finished();
     return (Vector(1) << x1).finished();
   }
@@ -388,15 +389,14 @@ class TestFactor4 : public NoiseModelFactor4<double, double, double, double> {
 
  public:
   typedef NoiseModelFactor4<double, double, double, double> Base;
+  using Base::evaluateError;
   TestFactor4() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4)) {}
   using Base::NoiseModelFactor4;  // inherit constructors
 
   Vector
     evaluateError(const double& x1, const double& x2, const double& x3, const double& x4,
-        OptionalMatrixType H1 = OptionalNone,
-        OptionalMatrixType H2 = OptionalNone,
-        OptionalMatrixType H3 = OptionalNone,
-        OptionalMatrixType H4 = OptionalNone) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2,
+        OptionalMatrixType H3, OptionalMatrixType H4) const override {
     if(H1) {
       *H1 = (Matrix(1, 1) << 1.0).finished();
       *H2 = (Matrix(1, 1) << 2.0).finished();
@@ -479,15 +479,13 @@ TEST(NonlinearFactor, NoiseModelFactor4) {
 class TestFactor5 : public NoiseModelFactor5<double, double, double, double, double> {
 public:
   typedef NoiseModelFactor5<double, double, double, double, double> Base;
+  using Base::evaluateError;
   TestFactor5() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4), X(5)) {}
 
   Vector
     evaluateError(const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5,
-        OptionalMatrixType H1 = OptionalNone,
-        OptionalMatrixType H2 = OptionalNone,
-        OptionalMatrixType H3 = OptionalNone,
-        OptionalMatrixType H4 = OptionalNone,
-        OptionalMatrixType H5 = OptionalNone) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3, 
+		OptionalMatrixType H4, OptionalMatrixType H5) const override {
     if(H1) {
       *H1 = (Matrix(1, 1) << 1.0).finished();
       *H2 = (Matrix(1, 1) << 2.0).finished();
@@ -529,16 +527,13 @@ TEST(NonlinearFactor, NoiseModelFactor5) {
 class TestFactor6 : public NoiseModelFactor6<double, double, double, double, double, double> {
 public:
   typedef NoiseModelFactor6<double, double, double, double, double, double> Base;
+  using Base::evaluateError;
   TestFactor6() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4), X(5), X(6)) {}
 
   Vector
     evaluateError(const X1& x1, const X2& x2, const X3& x3, const X4& x4, const X5& x5, const X6& x6,
-        OptionalMatrixType H1 = OptionalNone,
-        OptionalMatrixType H2 = OptionalNone,
-        OptionalMatrixType H3 = OptionalNone,
-        OptionalMatrixType H4 = OptionalNone,
-        OptionalMatrixType H5 = OptionalNone,
-        OptionalMatrixType H6 = OptionalNone) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2, OptionalMatrixType H3, OptionalMatrixType H4, 
+		OptionalMatrixType H5, OptionalMatrixType H6) const override {
     if(H1) {
       *H1 = (Matrix(1, 1) << 1.0).finished();
       *H2 = (Matrix(1, 1) << 2.0).finished();
@@ -587,16 +582,15 @@ TEST(NonlinearFactor, NoiseModelFactor6) {
 class TestFactorN : public NoiseModelFactorN<double, double, double, double> {
 public:
   typedef NoiseModelFactorN<double, double, double, double> Base;
+  using Base::evaluateError;
   using Type1 = ValueType<1>;  // Test that we can use the ValueType<> template
 
   TestFactorN() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4)) {}
 
   Vector
     evaluateError(const double& x1, const double& x2, const double& x3, const double& x4,
-        OptionalMatrixType H1 = OptionalNone,
-        OptionalMatrixType H2 = OptionalNone,
-        OptionalMatrixType H3 = OptionalNone,
-        OptionalMatrixType H4 = OptionalNone) const override {
+        OptionalMatrixType H1, OptionalMatrixType H2,
+        OptionalMatrixType H3, OptionalMatrixType H4) const override {
     if (H1) *H1 = (Matrix(1, 1) << 1.0).finished();
     if (H2) *H2 = (Matrix(1, 1) << 2.0).finished();
     if (H3) *H3 = (Matrix(1, 1) << 3.0).finished();

--- a/tests/testNonlinearFactor.cpp
+++ b/tests/testNonlinearFactor.cpp
@@ -337,8 +337,11 @@ class TestFactor1 : public NoiseModelFactor1<double> {
 
  public:
   typedef NoiseModelFactor1<double> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   TestFactor1() : Base(noiseModel::Diagonal::Sigmas(Vector1(2.0)), L(1)) {}
+  // Provide access to the Matrix& version of evaluateError:
   using Base::NoiseModelFactor1;  // inherit constructors
 
   Vector evaluateError(const double& x1, OptionalMatrixType H1) const override {
@@ -391,7 +394,9 @@ class TestFactor4 : public NoiseModelFactor4<double, double, double, double> {
   typedef NoiseModelFactor4<double, double, double, double> Base;
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   TestFactor4() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4)) {}
+  // Provide access to the Matrix& version of evaluateError:
   using Base::NoiseModelFactor4;  // inherit constructors
 
   Vector
@@ -482,6 +487,7 @@ public:
   typedef NoiseModelFactor5<double, double, double, double, double> Base;
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   TestFactor5() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4), X(5)) {}
 
   Vector
@@ -531,6 +537,7 @@ public:
   typedef NoiseModelFactor6<double, double, double, double, double, double> Base;
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   TestFactor6() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4), X(5), X(6)) {}
 
   Vector
@@ -587,6 +594,7 @@ public:
   typedef NoiseModelFactorN<double, double, double, double> Base;
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
+
   using Type1 = ValueType<1>;  // Test that we can use the ValueType<> template
 
   TestFactorN() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4)) {}

--- a/tests/testNonlinearFactor.cpp
+++ b/tests/testNonlinearFactor.cpp
@@ -337,10 +337,12 @@ class TestFactor1 : public NoiseModelFactor1<double> {
 
  public:
   typedef NoiseModelFactor1<double> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   TestFactor1() : Base(noiseModel::Diagonal::Sigmas(Vector1(2.0)), L(1)) {}
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::NoiseModelFactor1;  // inherit constructors
 
@@ -392,10 +394,12 @@ class TestFactor4 : public NoiseModelFactor4<double, double, double, double> {
 
  public:
   typedef NoiseModelFactor4<double, double, double, double> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
   TestFactor4() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4)) {}
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::NoiseModelFactor4;  // inherit constructors
 
@@ -485,6 +489,7 @@ TEST(NonlinearFactor, NoiseModelFactor4) {
 class TestFactor5 : public NoiseModelFactor5<double, double, double, double, double> {
 public:
   typedef NoiseModelFactor5<double, double, double, double, double> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -535,6 +540,7 @@ TEST(NonlinearFactor, NoiseModelFactor5) {
 class TestFactor6 : public NoiseModelFactor6<double, double, double, double, double, double> {
 public:
   typedef NoiseModelFactor6<double, double, double, double, double, double> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 
@@ -592,6 +598,7 @@ TEST(NonlinearFactor, NoiseModelFactor6) {
 class TestFactorN : public NoiseModelFactorN<double, double, double, double> {
 public:
   typedef NoiseModelFactorN<double, double, double, double> Base;
+
   // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
 

--- a/tests/testNonlinearFactor.cpp
+++ b/tests/testNonlinearFactor.cpp
@@ -389,6 +389,7 @@ class TestFactor4 : public NoiseModelFactor4<double, double, double, double> {
 
  public:
   typedef NoiseModelFactor4<double, double, double, double> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   TestFactor4() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4)) {}
   using Base::NoiseModelFactor4;  // inherit constructors
@@ -479,6 +480,7 @@ TEST(NonlinearFactor, NoiseModelFactor4) {
 class TestFactor5 : public NoiseModelFactor5<double, double, double, double, double> {
 public:
   typedef NoiseModelFactor5<double, double, double, double, double> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   TestFactor5() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4), X(5)) {}
 
@@ -527,6 +529,7 @@ TEST(NonlinearFactor, NoiseModelFactor5) {
 class TestFactor6 : public NoiseModelFactor6<double, double, double, double, double, double> {
 public:
   typedef NoiseModelFactor6<double, double, double, double, double, double> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   TestFactor6() : Base(noiseModel::Diagonal::Sigmas((Vector(1) << 2.0).finished()), X(1), X(2), X(3), X(4), X(5), X(6)) {}
 
@@ -582,6 +585,7 @@ TEST(NonlinearFactor, NoiseModelFactor6) {
 class TestFactorN : public NoiseModelFactorN<double, double, double, double> {
 public:
   typedef NoiseModelFactorN<double, double, double, double> Base;
+  // Provide access to the Matrix& version of evaluateError:
   using Base::evaluateError;
   using Type1 = ValueType<1>;  // Test that we can use the ValueType<> template
 

--- a/timing/timePose2.cpp
+++ b/timing/timePose2.cpp
@@ -37,7 +37,7 @@ Pose2 Pose2betweenDefault(const Pose2& r1, const Pose2& r2) {
 
 /* ************************************************************************* */
 Pose2 Pose2betweenOptimized(const Pose2& r1, const Pose2& r2,
-  boost::optional<Matrix&> H1 = boost::none, boost::optional<Matrix&> H2 = boost::none) {
+  OptionalJacobian<3,3> H1 = {}, OptionalJacobian<3,3> H2 = {}) {
   // get cosines and sines from rotation matrices
   const Rot2& R1 = r1.r(), R2 = r2.r();
   double c1=R1.c(), s1=R1.s(), c2=R2.c(), s2=R2.s();
@@ -69,42 +69,8 @@ Pose2 Pose2betweenOptimized(const Pose2& r1, const Pose2& r2,
 }
 
 /* ************************************************************************* */
-Pose2 Pose2betweenOptimized(const Pose2& r1, const Pose2& r2,
-  boost::optional<Matrix3&> H1, boost::optional<Matrix3&> H2)
-{
-  // get cosines and sines from rotation matrices
-  const Rot2& R1 = r1.r(), R2 = r2.r();
-  double c1=R1.c(), s1=R1.s(), c2=R2.c(), s2=R2.s();
-
-  // Assert that R1 and R2 are normalized
-  assert(std::abs(c1*c1 + s1*s1 - 1.0) < 1e-5 && std::abs(c2*c2 + s2*s2 - 1.0) < 1e-5);
-
-  // Calculate delta rotation = between(R1,R2)
-  double c = c1 * c2 + s1 * s2, s = -s1 * c2 + c1 * s2;
-  Rot2 R(Rot2::atan2(s,c)); // normalizes
-
-  // Calculate delta translation = unrotate(R1, dt);
-  Point2 dt = r2.t() - r1.t();
-  double x = dt.x(), y = dt.y();
-  Point2 t(c1 * x + s1 * y, -s1 * x + c1 * y);
-
-  // FD: This is just -AdjointMap(between(p2,p1)) inlined and re-using above
-  if (H1) {
-    double dt1 = -s2 * x + c2 * y;
-    double dt2 = -c2 * x - s2 * y;
-    *H1 = Matrix3(); (*H1) <<
-      -c,  -s,  dt1,
-      s,  -c,  dt2,
-      0.0, 0.0,-1.0;
-  }
-  if (H2) *H2 = I_3x3;
-
-  return Pose2(R,t);
-}
-
-/* ************************************************************************* */
 Vector Pose2BetweenFactorEvaluateErrorDefault(const Pose2& measured, const Pose2& p1, const Pose2& p2,
-  boost::optional<Matrix&> H1, boost::optional<Matrix&> H2)
+  OptionalJacobian<3,3> H1, OptionalJacobian<3,3> H2)
 {
   Pose2 hx = p1.between(p2, H1, H2); // h(x)
   // manifold equivalent of h(x)-z -> log(z,h(x))
@@ -113,7 +79,7 @@ Vector Pose2BetweenFactorEvaluateErrorDefault(const Pose2& measured, const Pose2
 
 /* ************************************************************************* */
 Vector Pose2BetweenFactorEvaluateErrorOptimizedBetween(const Pose2& measured, const Pose2& p1, const Pose2& p2,
-  boost::optional<Matrix&> H1, boost::optional<Matrix&> H2)
+  OptionalJacobian<3,3> H1, OptionalJacobian<3,3> H2)
 {
   Pose2 hx = Pose2betweenOptimized(p1, p2, H1, H2); // h(x)
   // manifold equivalent of h(x)-z -> log(z,h(x))
@@ -122,7 +88,7 @@ Vector Pose2BetweenFactorEvaluateErrorOptimizedBetween(const Pose2& measured, co
 
 /* ************************************************************************* */
 Vector Pose2BetweenFactorEvaluateErrorOptimizedBetweenFixed(const Pose2& measured, const Pose2& p1, const Pose2& p2,
-  boost::optional<Matrix3&> H1, boost::optional<Matrix3&> H2)
+  OptionalJacobian<3,3> H1, OptionalJacobian<3,3> H2)
 {
   // TODO: Implement
   Pose2 hx = Pose2betweenOptimized(p1, p2, H1, H2); // h(x)

--- a/timing/timeRot2.cpp
+++ b/timing/timeRot2.cpp
@@ -19,6 +19,7 @@
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/base/timing.h>
 #include <iostream>
+#include "gtsam/base/OptionalJacobian.h"
 
 using namespace std;
 using namespace gtsam;
@@ -43,7 +44,7 @@ Rot2 Rot2betweenOptimized(const Rot2& r1, const Rot2& r2) {
 
 /* ************************************************************************* */
 Vector Rot2BetweenFactorEvaluateErrorDefault(const Rot2& measured, const Rot2& p1, const Rot2& p2,
-  boost::optional<Matrix&> H1, boost::optional<Matrix&> H2)
+  OptionalJacobian<1,1> H1, OptionalJacobian<1,1> H2)
 {
   Rot2 hx = p1.between(p2, H1, H2); // h(x)
   // manifold equivalent of h(x)-z -> log(z,h(x))
@@ -52,7 +53,7 @@ Vector Rot2BetweenFactorEvaluateErrorDefault(const Rot2& measured, const Rot2& p
 
 /* ************************************************************************* */
 Vector Rot2BetweenFactorEvaluateErrorOptimizedBetween(const Rot2& measured, const Rot2& p1, const Rot2& p2,
-  boost::optional<Matrix&> H1, boost::optional<Matrix&> H2)
+  OptionalJacobian<1,1> H1, OptionalJacobian<1,1> H2)
 {
   Rot2 hx = Rot2betweenOptimized(p1, p2); // h(x)
   if (H1) *H1 = -I_1x1;
@@ -63,7 +64,7 @@ Vector Rot2BetweenFactorEvaluateErrorOptimizedBetween(const Rot2& measured, cons
 
 /* ************************************************************************* */
 Vector Rot2BetweenFactorEvaluateErrorOptimizedBetweenNoeye(const Rot2& measured, const Rot2& p1, const Rot2& p2,
-  boost::optional<Matrix&> H1, boost::optional<Matrix&> H2)
+  OptionalJacobian<1,1> H1, OptionalJacobian<1,1> H2)
 {
   // TODO: Implement
   Rot2 hx = Rot2betweenOptimized(p1, p2); // h(x)
@@ -76,7 +77,7 @@ Vector Rot2BetweenFactorEvaluateErrorOptimizedBetweenNoeye(const Rot2& measured,
 /* ************************************************************************* */
 typedef Eigen::Matrix<double,1,1> Matrix1;
 Vector Rot2BetweenFactorEvaluateErrorOptimizedBetweenFixed(const Rot2& measured, const Rot2& p1, const Rot2& p2,
-  boost::optional<Matrix1&> H1, boost::optional<Matrix1&> H2)
+  OptionalJacobian<1,1> H1, OptionalJacobian<1,1> H2)
 {
   // TODO: Implement
   Rot2 hx = Rot2betweenOptimized(p1, p2); // h(x)


### PR DESCRIPTION
# Overview 

This PR is part of a push to upgrade GTSAM to C++17, and remove boost dependencies from GTSAM. In this PR we want to update our factor interfaces and the factor implementations that use arguments of the type boost::optional<A&> to raw pointers of the type A*. We wish to do that because the semantics of raw pointers are the same as that of an optional to a reference. This is in accordance to google style guide’s recommendation for function input parameters, [link here](https://google.github.io/styleguide/cppguide.html#Inputs_and_Outputs).

# Details

## Retaining `evaluateError` interface to accept both pointers and matrices
This was achieved by some templating and conditional compilation in `NoiseModelFactorN` class. A side-effect of this is that when a user inherits NoiseModelFactorN and implements it, they have to do something like this-
`using Base::evaluateError;` for all of the evaluateError overloads to be visible for the end user.

## Replacing std::binds with lambdas
std::bind had a problem inferring which evaluateError overload to use through template deduction. I replaced it with lambdas instead.

##  `OptionalJacobian`
I have replaced `boost::optional<Matrix&>` in functions whose, input argument sizes are known, with OptionalJacobians. This enables us to use that function with both pointers and l-value references of matrices.

# TODO
- [ ] Need to update `GeoGraphicLibs` and compile some tests that were excluded.
- [ ] Need to still replace `boost::optional<Matrix&>` in the following lines of code after discussing with Frank:
```
 gtsam/geometry/CameraSet.h
112:      boost::optional<Matrix&> E = boost::none) const {
141:      boost::optional<Matrix&> E = boost::none) const {

gtsam/base/tests/testOptionalJacobian.cpp
35:  boost::optional<Matrix&> optional(dynamic);

gtsam/slam/SmartFactorBase.h
207:      boost::optional<Matrix&> E = boost::none) const {
244:      boost::optional<Matrix&> E = boost::none) const {}

gtsam_unstable/slam/SmartStereoProjectionFactor.h
457:      boost::optional<Matrix&> E = boost::none) const override {
```
- [ ] Need a review on `Pose3Upright.cpp` 
- [ ]  Need a review on `timePose2.cpp` (Deleted a test which looked like a copy paste to me)